### PR TITLE
Feature consistent scrolling

### DIFF
--- a/xpano/constants.h
+++ b/xpano/constants.h
@@ -12,4 +12,6 @@ constexpr int kWindowHeight = 800;
 
 constexpr float kZoomFactor = 2.0f;
 constexpr int kZoomLevels = 10;
+
+constexpr int kResizingDelayFrames = 30;
 }  // namespace xpano

--- a/xpano/gui/thumbnail_pane.h
+++ b/xpano/gui/thumbnail_pane.h
@@ -6,6 +6,7 @@
 #include <SDL.h>
 
 #include "algorithm/image.h"
+#include "constants.h"
 #include "gui/action.h"
 #include "utils/sdl_.h"
 #include "utils/vec.h"
@@ -29,6 +30,35 @@ class HoverChecker {
   int styles_pushed_ = 0;
   bool allow_modification_ = false;
   std::vector<int> highlighted_ids_;
+};
+
+class AutoScroller {
+ public:
+  void SetNeedsRescroll();
+  [[nodiscard]] bool NeedsRescroll() const;
+  void Rescroll();
+
+ private:
+  bool needs_rescroll_ = false;
+  float scroll_ratio_ = 0.0f;
+};
+
+class ResizeChecker {
+ public:
+  enum class Status {
+    kIdle,
+    kResizing,
+    kResized,
+  };
+
+  explicit ResizeChecker(int delay = kResizingDelayFrames);
+  Status Check(ImVec2 window_size);
+
+ private:
+  const int delay_;
+
+  int resizing_streak_ = 0;
+  ImVec2 window_size_ = {0, 0};
 };
 
 class ThumbnailPane {
@@ -59,13 +89,10 @@ class ThumbnailPane {
   std::vector<Coord> coords_;
   std::vector<float> scroll_;
 
-  int scroll_id_ = 0;
-  ImVec2 window_size_ = ImVec2(0, 0);
-  float last_thumbnail_height_ = 0.0f;
-  int resizing_streak_ = 0;
+  AutoScroller auto_scroller_;
+  ResizeChecker resize_checker_;
 
-  float scroll_ratio_ = 0.0f;
-  bool rescroll_ = false;
+  float thumbnail_height_ = 0.0f;
 
   HoverChecker hover_checker_;
   SDL_Renderer *renderer_;


### PR DESCRIPTION
Functionality: 
After the user resizes the thumbnail bar, the app rescrolls to the original location.
During the resizing event the size of the thumbnails is fixed, so that the whole thumbnail pane doesn't move around wildly.

The optimal solution would both resize the thumbnails and readjust scroll on the fly, however that is quite difficult to accomplish in ImGui partly due to the fact that the SetScroll* functions only apply on next frame (https://github.com/ocornut/imgui/issues/1526).