### PR TITLE
Refactor PanoGui

### DIFF
--- a/xpano/gui/action.h
+++ b/xpano/gui/action.h
@@ -5,6 +5,7 @@ namespace xpano::gui {
 enum class ActionType {
   kNone,
   kCancelPipeline,
+  kDisableHighlight,
   kExport,
   kOpenDirectory,
   kOpenFiles,

--- a/xpano/gui/panels/about.cc
+++ b/xpano/gui/panels/about.cc
@@ -1,5 +1,7 @@
 #include "gui/panels/about.h"
 
+#include <algorithm>
+#include <iterator>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -76,8 +78,8 @@ void AboutPane::Draw() {
 
   if (licenses_.size() == 1 &&
       xpano::utils::future::IsReady(licenses_future_)) {
-    auto temp_licenses_ = licenses_future_.get();
-    std::copy(temp_licenses_.begin(), temp_licenses_.end(),
+    auto temp_licenses = licenses_future_.get();
+    std::copy(temp_licenses.begin(), temp_licenses.end(),
               std::back_inserter(licenses_));
   }
 

--- a/xpano/gui/panels/about.h
+++ b/xpano/gui/panels/about.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <future>
-#include <vector>
 
 #include "utils/text.h"
 

--- a/xpano/gui/panels/preview_pane.cc
+++ b/xpano/gui/panels/preview_pane.cc
@@ -108,8 +108,7 @@ void PreviewPane::Draw(const std::string& message) {
     auto p_min = mid - image_size / 2.0f;
     auto p_max = mid + image_size / 2.0f;
     if (IsZoomed()) {
-      p_min = utils::ToPoint(ImGui::GetCursorScreenPos()) +
-              available_size * screen_offset_ -
+      p_min = window_start + available_size * screen_offset_ -
               image_size * image_offset_ * Zoom();
       p_max = p_min + image_size * Zoom();
     }

--- a/xpano/gui/panels/sidebar.cc
+++ b/xpano/gui/panels/sidebar.cc
@@ -14,6 +14,7 @@
 #include "constants.h"
 #include "gui/action.h"
 #include "gui/panels/thumbnail_pane.h"
+#include "utils/imgui_.h"
 
 namespace xpano::gui {
 
@@ -198,6 +199,26 @@ Action DrawMenu(algorithm::CompressionOptions* compression_options) {
     ImGui::EndMenuBar();
   }
   return action;
+}
+
+void DrawWelcomeText() {
+  ImGui::Text("Welcome to Xpano!");
+  ImGui::Text(" 1) Import your images");
+  ImGui::SameLine();
+  utils::imgui::InfoMarker(
+      "(?)", "a) Import individual files\nb) Import all files in a directory");
+  ImGui::Text(" 2) Select a panorama");
+  ImGui::SameLine();
+  utils::imgui::InfoMarker(
+      "(?)",
+      "a) Pick one of the autodetected panoramas\nb) CTRL click on thumbnails "
+      "to add / edit / delete panoramas\nc) Zoom and pan the images with your "
+      "mouse");
+  ImGui::Text(" 3) Export");
+  ImGui::SameLine();
+  utils::imgui::InfoMarker("(?)",
+                           "a) Keyboard shortcut: CTRL+S\nb) Exported panos "
+                           "will be marked by a check mark");
 }
 
 }  // namespace xpano::gui

--- a/xpano/gui/panels/sidebar.h
+++ b/xpano/gui/panels/sidebar.h
@@ -25,4 +25,6 @@ Action DrawPanosMenu(const std::vector<algorithm::Pano>& panos,
 
 Action DrawMenu(algorithm::CompressionOptions* compression_options);
 
+void DrawWelcomeText();
+
 }  // namespace xpano::gui

--- a/xpano/gui/pano_gui.cc
+++ b/xpano/gui/pano_gui.cc
@@ -1,9 +1,9 @@
 #include "gui/pano_gui.h"
 
 #include <algorithm>
-#include <chrono>
 #include <future>
 #include <optional>
+#include <ostream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/xpano/gui/pano_gui.cc
+++ b/xpano/gui/pano_gui.cc
@@ -113,23 +113,7 @@ Action PanoGui::DrawSidebar() {
                ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoScrollbar);
   action |= DrawMenu(&compression_options_);
 
-  ImGui::Text("Welcome to Xpano!");
-  ImGui::Text(" 1) Import your images");
-  ImGui::SameLine();
-  utils::imgui::InfoMarker(
-      "(?)", "a) Import individual files\nb) Import all files in a directory");
-  ImGui::Text(" 2) Select a panorama");
-  ImGui::SameLine();
-  utils::imgui::InfoMarker(
-      "(?)",
-      "a) Pick one of the autodetected panoramas\nb) CTRL click on thumbnails "
-      "to add / edit / delete panoramas\nc) Zoom and pan the images with your "
-      "mouse");
-  ImGui::Text(" 3) Export");
-  ImGui::SameLine();
-  utils::imgui::InfoMarker("(?)",
-                           "a) Keyboard shortcut: CTRL+S\nb) Exported panos "
-                           "will be marked by a check mark");
+  DrawWelcomeText();
   ImGui::Separator();
 
   auto progress = stitcher_pipeline_.LoadingProgress();
@@ -307,13 +291,13 @@ Action PanoGui::ResolveFutures() {
     try {
       stitcher_data_ = stitcher_data_future_.get();
     } catch (const std::exception& e) {
-      spdlog::error("Error loading images: {}", e.what());
       status_message_ = {"Couldn't load images", e.what()};
+      spdlog::error(status_message_);
       return {};
     }
     if (stitcher_data_->images.empty()) {
-      spdlog::info("No images loaded");
       status_message_ = {"No images loaded"};
+      spdlog::info(status_message_);
       stitcher_data_.reset();
       return {};
     }
@@ -335,8 +319,8 @@ Action PanoGui::ResolveFutures() {
         plot_pane_.Load(*result.pano);
       }
     } catch (const std::exception& e) {
-      spdlog::error("Error stitching pano: {}", e.what());
       status_message_ = {"Failed to stitch pano", e.what()};
+      spdlog::error(status_message_);
       return {};
     }
     if (!result.pano) {

--- a/xpano/gui/pano_gui.h
+++ b/xpano/gui/pano_gui.h
@@ -20,6 +20,11 @@ namespace xpano::gui {
 template <typename TType>
 bool IsReady(const std::future<TType>& future);
 
+struct StatusMessage {
+  std::string basic;
+  std::string details;
+};
+
 class PanoGui {
  public:
   PanoGui(backends::Base* backend, logger::LoggerGui* logger,
@@ -41,8 +46,7 @@ class PanoGui {
   int selected_match_ = -1;
   Action delayed_action_ = {ActionType::kNone};
 
-  std::string info_message_;
-  std::string tooltip_message_;
+  StatusMessage status_message_;
 
   Layout layout_;
   logger::LoggerGui* logger_;

--- a/xpano/gui/pano_gui.h
+++ b/xpano/gui/pano_gui.h
@@ -21,8 +21,8 @@ template <typename TType>
 bool IsReady(const std::future<TType>& future);
 
 struct StatusMessage {
-  std::string basic;
-  std::string details;
+  std::string text;
+  std::string tooltip;
 };
 
 enum class SelectionType {

--- a/xpano/gui/pano_gui.h
+++ b/xpano/gui/pano_gui.h
@@ -3,7 +3,6 @@
 #include <future>
 #include <optional>
 #include <string>
-#include <vector>
 
 #include "algorithm/stitcher_pipeline.h"
 #include "gui/action.h"

--- a/xpano/gui/pano_gui.h
+++ b/xpano/gui/pano_gui.h
@@ -25,6 +25,18 @@ struct StatusMessage {
   std::string details;
 };
 
+enum class SelectionType {
+  kNone,
+  kImage,
+  kMatch,
+  kPano,
+};
+
+struct Selection {
+  SelectionType type = SelectionType::kNone;
+  int target_id = -1;
+};
+
 class PanoGui {
  public:
   PanoGui(backends::Base* backend, logger::LoggerGui* logger,
@@ -39,11 +51,8 @@ class PanoGui {
   void ResetSelections(Action action);
   Action PerformAction(Action action);
   Action ModifyPano(Action action);
-  std::string PreviewMessage() const;
 
-  int selected_image_ = -1;
-  int selected_pano_ = -1;
-  int selected_match_ = -1;
+  Selection selection_;
   Action delayed_action_ = {ActionType::kNone};
 
   StatusMessage status_message_;

--- a/xpano/gui/pano_gui.h
+++ b/xpano/gui/pano_gui.h
@@ -48,13 +48,11 @@ class PanoGui {
   Action DrawGui();
   Action DrawSidebar();
   Action ResolveFutures();
-  void ResetSelections(Action action);
   Action PerformAction(Action action);
-  Action ModifyPano(Action action);
+  void Reset();
 
   Selection selection_;
   Action delayed_action_ = {ActionType::kNone};
-
   StatusMessage status_message_;
 
   Layout layout_;

--- a/xpano/main.cc
+++ b/xpano/main.cc
@@ -18,6 +18,7 @@
 
 #include <clocale>
 #include <cstdio>
+#include <future>
 #include <string>
 #include <utility>
 

--- a/xpano/utils/future.h
+++ b/xpano/utils/future.h
@@ -2,9 +2,7 @@
 
 #include <future>
 
-namespace xpano::utils {
-
-namespace future {
+namespace xpano::utils::future {
 
 template <typename TType>
 bool IsReady(const std::future<TType>& future) {
@@ -12,6 +10,4 @@ bool IsReady(const std::future<TType>& future) {
          future.wait_for(std::chrono::seconds(0)) == std::future_status::ready;
 }
 
-}  // namespace future
-
-}  // namespace xpano::utils
+}  // namespace xpano::utils::future

--- a/xpano/utils/future.h
+++ b/xpano/utils/future.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <future>
 
 namespace xpano::utils::future {


### PR DESCRIPTION
Refactor the main PanoGui class for greater readability / maintainability.

- Isolated code to free functions, so that it is obvious what is their input/output. Most notably the `ModifyPano` function
    - Lines of code in PanoGui class implementation went from 310 to 228
- Replaced integer members (`selected_*`) with a struct `selection_`, where `selection_.type` is one of `kImage, kMatch, kPano`
- Replaced `info_message_` and `tooltip_message` with a single `status_message_` that can be directly passed to spdlog
