### PR TITLE
Feature search strategy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ set(XPANO_SOURCES
   "xpano/gui/panels/sidebar.cc"
   "xpano/gui/panels/thumbnail_pane.cc"
   "xpano/gui/pano_gui.cc"
+  "xpano/utils/disjoint_set.cc"
   "xpano/utils/imgui_.cc"
   "xpano/utils/resource.cc"
   "xpano/utils/sdl_.cc"

--- a/misc/mappings/iwyu_win.imp
+++ b/misc/mappings/iwyu_win.imp
@@ -10,4 +10,7 @@
   { include: ["<spdlog/fmt/bundled/core.h>", "private", "<spdlog/fmt/fmt.h>", "public"] },
   { include: ["<spdlog/fmt/bundled/format.h>", "private", "<spdlog/fmt/fmt.h>", "public"] },
   { include: ["<__msvc_chrono.hpp>", "private", "<chrono>", "public"] },
+  { symbol: [ "std::min", private, "<algorithm>", public ] },
+  { symbol: [ "std::max", private, "<algorithm>", public ] },
+  { include: ["<compare>", "public", "<string>", "public"] },
 ]

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,8 @@ add_executable(StitcherTest
   stitcher_test.cc
   ../xpano/algorithm/algorithm.cc
   ../xpano/algorithm/image.cc
-  ../xpano/algorithm/stitcher_pipeline.cc)
+  ../xpano/algorithm/stitcher_pipeline.cc
+  ../xpano/utils/disjoint_set.cc)
 
 target_link_libraries(StitcherTest 
   Catch2::Catch2WithMain
@@ -35,7 +36,21 @@ target_include_directories(VecTest PRIVATE
   "../xpano"
 )
 
+add_executable(DisjointSetTest 
+  disjoint_set_test.cc
+  ../xpano/utils/disjoint_set.cc
+)
+
+target_link_libraries(DisjointSetTest 
+  Catch2::Catch2WithMain
+)
+
+target_include_directories(DisjointSetTest PRIVATE 
+  "../xpano"
+)
+
 set(ALL_TEST_TARGETS
+  DisjointSetTest
   StitcherTest
   VecTest
 )

--- a/tests/disjoint_set_test.cc
+++ b/tests/disjoint_set_test.cc
@@ -1,0 +1,24 @@
+#include "utils/disjoint_set.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+using xpano::utils::DisjointSet;
+
+TEST_CASE("DisjointSet constructor") {
+  auto set = DisjointSet(3);
+  CHECK(set.Find(0) == 0);
+  CHECK(set.Find(1) == 1);
+  CHECK(set.Find(2) == 2);
+}
+
+TEST_CASE("DisjointSet Union/Find") {
+  auto set = DisjointSet(3);
+
+  set.Union(0, 1);
+  CHECK(set.Find(0) == set.Find(1));
+  CHECK(set.Find(2) == 2);
+
+  set.Union(1, 2);
+  CHECK(set.Find(0) == set.Find(1));
+  CHECK(set.Find(1) == set.Find(2));
+}

--- a/tests/stitcher_test.cc
+++ b/tests/stitcher_test.cc
@@ -96,7 +96,7 @@ TEST_CASE("Stitcher pipeline single image") {
   CHECK(progress.tasks_done == progress.num_tasks);
 
   REQUIRE(result.images.size() == 1);
-  REQUIRE(result.matches.size() == 0);
+  REQUIRE(result.matches.empty());
 }
 
 TEST_CASE("Stitcher pipeline no images") {
@@ -106,6 +106,6 @@ TEST_CASE("Stitcher pipeline no images") {
   auto progress = stitcher.LoadingProgress();
   CHECK(progress.tasks_done == progress.num_tasks);
 
-  REQUIRE(result.images.size() == 0);
-  REQUIRE(result.matches.size() == 0);
+  REQUIRE(result.images.empty());
+  REQUIRE(result.matches.empty());
 }

--- a/xpano/algorithm/algorithm.cc
+++ b/xpano/algorithm/algorithm.cc
@@ -79,12 +79,13 @@ std::vector<cv::DMatch> MatchImages(const Image& img1, const Image& img2) {
   return inliers;
 }
 
-std::vector<Pano> FindPanos(const std::vector<Match>& matches, int num_images) {
+std::vector<Pano> FindPanos(const std::vector<Match>& matches, int num_images,
+                            int match_threshold) {
   auto pano_ds = utils::DisjointSet(num_images);
 
   std::unordered_set<int> images_in_panos;
   for (const auto& match : matches) {
-    if (match.matches.size() > kMatchThreshold) {
+    if (match.matches.size() > match_threshold) {
       pano_ds.Union(match.id1, match.id2);
       images_in_panos.insert(match.id1);
       images_in_panos.insert(match.id2);

--- a/xpano/algorithm/algorithm.cc
+++ b/xpano/algorithm/algorithm.cc
@@ -1,6 +1,10 @@
 #include "algorithm/algorithm.h"
 
+#include <algorithm>
+#include <iterator>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -11,8 +15,16 @@
 
 #include "algorithm/image.h"
 #include "constants.h"
+#include "utils/disjoint_set.h"
 
 namespace xpano::algorithm {
+
+namespace {
+void InsertInOrder(int value, std::vector<int>* vec) {
+  auto it = std::lower_bound(vec->begin(), vec->end(), value);
+  vec->insert(it, value);
+}
+}  // namespace
 
 std::vector<cv::DMatch> MatchImages(const Image& img1, const Image& img2) {
   if (img1.GetKeypoints().empty() || img2.GetKeypoints().empty()) {
@@ -67,37 +79,38 @@ std::vector<cv::DMatch> MatchImages(const Image& img1, const Image& img2) {
   return inliers;
 }
 
-std::vector<Pano> FindPanos(const std::vector<Match>& matches) {
-  using MMatch = std::pair<int, int>;
+std::vector<Pano> FindPanos(const std::vector<Match>& matches, int num_images) {
+  auto pano_ds = utils::DisjointSet(num_images);
 
-  std::vector<MMatch> good_matches;
+  std::unordered_set<int> images_in_panos;
   for (const auto& match : matches) {
     if (match.matches.size() > kMatchThreshold) {
-      good_matches.emplace_back(match.id1, match.id2);
+      pano_ds.Union(match.id1, match.id2);
+      images_in_panos.insert(match.id1);
+      images_in_panos.insert(match.id2);
     }
   }
 
-  if (good_matches.empty()) {
+  if (images_in_panos.empty()) {
     return {};
   }
 
-  std::vector<Pano> result;
-  Pano next{};
-  next.ids.push_back(good_matches[0].first);
-  next.ids.push_back(good_matches[0].second);
-
-  for (int i = 1; i < good_matches.size(); i++) {
-    const auto& match = good_matches[i];
-    if (next.ids.back() == match.first) {
-      next.ids.push_back(match.second);
+  std::unordered_map<int, Pano> pano_map;
+  for (auto image_id : images_in_panos) {
+    int root = pano_ds.Find(image_id);
+    if (auto pano = pano_map.find(root); pano != pano_map.end()) {
+      InsertInOrder(image_id, &pano->second.ids);
     } else {
-      result.push_back(next);
-      next.ids.resize(0);
-      next.ids.push_back(match.first);
-      next.ids.push_back(match.second);
+      pano_map.emplace(root, Pano{.ids = {image_id}});
     }
   }
-  result.push_back(next);
+
+  std::vector<Pano> result;
+  std::transform(pano_map.begin(), pano_map.end(), std::back_inserter(result),
+                 [](const auto& pano) { return pano.second; });
+  std::sort(result.begin(), result.end(), [](const Pano& p1, const Pano& p2) {
+    return p1.ids[0] < p2.ids[0];
+  });
   return result;
 }
 

--- a/xpano/algorithm/algorithm.cc
+++ b/xpano/algorithm/algorithm.cc
@@ -21,8 +21,8 @@ namespace xpano::algorithm {
 
 namespace {
 void InsertInOrder(int value, std::vector<int>* vec) {
-  auto it = std::lower_bound(vec->begin(), vec->end(), value);
-  vec->insert(it, value);
+  auto iter = std::lower_bound(vec->begin(), vec->end(), value);
+  vec->insert(iter, value);
 }
 }  // namespace
 
@@ -108,8 +108,8 @@ std::vector<Pano> FindPanos(const std::vector<Match>& matches, int num_images) {
   std::vector<Pano> result;
   std::transform(pano_map.begin(), pano_map.end(), std::back_inserter(result),
                  [](const auto& pano) { return pano.second; });
-  std::sort(result.begin(), result.end(), [](const Pano& p1, const Pano& p2) {
-    return p1.ids[0] < p2.ids[0];
+  std::sort(result.begin(), result.end(), [](const Pano& lhs, const Pano& rhs) {
+    return lhs.ids[0] < rhs.ids[0];
   });
   return result;
 }

--- a/xpano/algorithm/algorithm.h
+++ b/xpano/algorithm/algorithm.h
@@ -24,7 +24,8 @@ struct Match {
 
 std::vector<cv::DMatch> MatchImages(const Image& img1, const Image& img2);
 
-std::vector<Pano> FindPanos(const std::vector<Match>& matches, int num_images);
+std::vector<Pano> FindPanos(const std::vector<Match>& matches, int num_images,
+                            int match_threshold);
 
 std::pair<cv::Stitcher::Status, cv::Mat> Stitch(
     const std::vector<cv::Mat>& images);

--- a/xpano/algorithm/algorithm.h
+++ b/xpano/algorithm/algorithm.h
@@ -24,7 +24,7 @@ struct Match {
 
 std::vector<cv::DMatch> MatchImages(const Image& img1, const Image& img2);
 
-std::vector<Pano> FindPanos(const std::vector<Match>& matches);
+std::vector<Pano> FindPanos(const std::vector<Match>& matches, int num_images);
 
 std::pair<cv::Stitcher::Status, cv::Mat> Stitch(
     const std::vector<cv::Mat>& images);

--- a/xpano/algorithm/stitcher_pipeline.cc
+++ b/xpano/algorithm/stitcher_pipeline.cc
@@ -65,12 +65,12 @@ void StitcherPipeline::Cancel() {
 }
 
 std::future<StitcherData> StitcherPipeline::RunLoading(
-    const std::vector<std::string> &inputs, const LoadingOptions &options) {
-  options_ = options;
-
-  return pool_.submit([this, inputs]() {
+    const std::vector<std::string> &inputs,
+    const LoadingOptions &loading_options,
+    const MatchingOptions &matching_options) {
+  return pool_.submit([this, matching_options, inputs]() {
     auto images = RunLoadingPipeline(inputs);
-    return RunMatchingPipeline(images);
+    return RunMatchingPipeline(images, matching_options);
   });
 }
 
@@ -150,21 +150,30 @@ std::vector<algorithm::Image> StitcherPipeline::RunLoadingPipeline(
 }
 
 StitcherData StitcherPipeline::RunMatchingPipeline(
-    std::vector<algorithm::Image> images) {
+    std::vector<algorithm::Image> images, const MatchingOptions &options) {
   if (images.empty()) {
     return {};
   }
 
-  int num_tasks = static_cast<int>(images.size());
+  int num_images = static_cast<int>(images.size());
+  int num_neighbors =
+      std::min(options.neighborhood_search_size, num_images - 1);
+  int num_tasks =
+      1 +                                             // FindPanos
+      (num_images - num_neighbors) * num_neighbors +  // full n-tuples
+      ((num_neighbors - 1) * num_neighbors) / 2;      // non-full (j - i < 0)
+
   loading_progress_.Reset(ProgressType::kMatchingImages, num_tasks);
   BS::multi_future<Match> matches_future;
-  for (int i = 1; i < images.size(); i++) {
-    matches_future.push_back(
-        pool_.submit([this, i, left = images[i - 1], right = images[i]]() {
-          auto match = Match{i - 1, i, MatchImages(left, right)};
-          loading_progress_.NotifyTaskDone();
-          return match;
-        }));
+  for (int j = 0; j < images.size(); j++) {
+    for (int i = std::max(0, j - num_neighbors); i < j; i++) {
+      matches_future.push_back(
+          pool_.submit([this, i, j, left = images[i], right = images[j]]() {
+            auto match = Match{i, j, MatchImages(left, right)};
+            loading_progress_.NotifyTaskDone();
+            return match;
+          }));
+    }
   }
 
   std::future_status status;
@@ -176,7 +185,7 @@ StitcherData StitcherPipeline::RunMatchingPipeline(
   }
   auto matches = matches_future.get();
 
-  auto panos = FindPanos(matches);
+  auto panos = FindPanos(matches, num_images);
   loading_progress_.NotifyTaskDone();
   return StitcherData{images, matches, panos};
 }

--- a/xpano/algorithm/stitcher_pipeline.cc
+++ b/xpano/algorithm/stitcher_pipeline.cc
@@ -1,5 +1,6 @@
 #include "algorithm/stitcher_pipeline.h"
 
+#include <algorithm>
 #include <atomic>
 #include <future>
 #include <optional>

--- a/xpano/algorithm/stitcher_pipeline.cc
+++ b/xpano/algorithm/stitcher_pipeline.cc
@@ -186,7 +186,7 @@ StitcherData StitcherPipeline::RunMatchingPipeline(
   }
   auto matches = matches_future.get();
 
-  auto panos = FindPanos(matches, num_images);
+  auto panos = FindPanos(matches, num_images, options.match_threshold);
   loading_progress_.NotifyTaskDone();
   return StitcherData{images, matches, panos};
 }

--- a/xpano/algorithm/stitcher_pipeline.cc
+++ b/xpano/algorithm/stitcher_pipeline.cc
@@ -66,7 +66,7 @@ void StitcherPipeline::Cancel() {
 
 std::future<StitcherData> StitcherPipeline::RunLoading(
     const std::vector<std::string> &inputs,
-    const LoadingOptions &loading_options,
+    const LoadingOptions & /*loading_options*/,
     const MatchingOptions &matching_options) {
   return pool_.submit([this, matching_options, inputs]() {
     auto images = RunLoadingPipeline(inputs);

--- a/xpano/algorithm/stitcher_pipeline.h
+++ b/xpano/algorithm/stitcher_pipeline.h
@@ -23,8 +23,12 @@ struct CompressionOptions {
   int png_compression = kDefaultPngCompression;
 };
 
+struct MatchingOptions {
+  int neighborhood_search_size = kDefaultNeighborhoodSearchSize;
+};
+
 struct LoadingOptions {
-  int image_downsample_factor = 1;
+  // int image_downsample_factor = 1;
 };
 
 struct StitchingOptions {
@@ -79,7 +83,8 @@ class StitcherPipeline {
   StitcherPipeline() = default;
   ~StitcherPipeline();
   std::future<StitcherData> RunLoading(const std::vector<std::string> &inputs,
-                                       const LoadingOptions &options);
+                                       const LoadingOptions &loading_options,
+                                       const MatchingOptions &matching_options);
   std::future<StitchingResult> RunStitching(const StitcherData &data,
                                             const StitchingOptions &options);
   ProgressReport LoadingProgress() const;
@@ -89,10 +94,10 @@ class StitcherPipeline {
  private:
   std::vector<algorithm::Image> RunLoadingPipeline(
       const std::vector<std::string> &inputs);
-  StitcherData RunMatchingPipeline(std::vector<algorithm::Image> images);
+  StitcherData RunMatchingPipeline(std::vector<algorithm::Image> images,
+                                   const MatchingOptions &options);
 
   ProgressMonitor loading_progress_;
-  LoadingOptions options_;
 
   std::atomic<bool> cancel_tasks_ = false;
   BS::thread_pool pool_;

--- a/xpano/algorithm/stitcher_pipeline.h
+++ b/xpano/algorithm/stitcher_pipeline.h
@@ -25,6 +25,7 @@ struct CompressionOptions {
 
 struct MatchingOptions {
   int neighborhood_search_size = kDefaultNeighborhoodSearchSize;
+  int match_threshold = kDefaultMatchThreshold;
 };
 
 struct LoadingOptions {

--- a/xpano/constants.h
+++ b/xpano/constants.h
@@ -50,5 +50,6 @@ const std::string kSymbolsFontPath = "assets/NotoSansSymbols2-Regular.ttf";
 const std::string kIconPath = "assets/icon.png";
 
 constexpr int kDefaultNeighborhoodSearchSize = 2;
+constexpr int kMaxNeighborhoodSearchSize = 10;
 
 }  // namespace xpano

--- a/xpano/constants.h
+++ b/xpano/constants.h
@@ -49,4 +49,6 @@ const std::string kFontPath = "assets/NotoSans-Regular.ttf";
 const std::string kSymbolsFontPath = "assets/NotoSansSymbols2-Regular.ttf";
 const std::string kIconPath = "assets/icon.png";
 
+constexpr int kDefaultNeighborhoodSearchSize = 2;
+
 }  // namespace xpano

--- a/xpano/constants.h
+++ b/xpano/constants.h
@@ -10,7 +10,9 @@ constexpr int kNumFeatures = 3000;
 constexpr int kPreviewSize = 256;
 constexpr int kMaxTexSize = 16384;
 constexpr int kLoupeSize = 4096;
-constexpr int kMatchThreshold = 70;
+constexpr int kMinMatchThreshold = 4;
+constexpr int kDefaultMatchThreshold = 70;
+constexpr int kMaxMatchThreshold = 250;
 
 constexpr int kWindowWidth = 1280;
 constexpr int kWindowHeight = 800;

--- a/xpano/gui/file_dialog.cc
+++ b/xpano/gui/file_dialog.cc
@@ -65,6 +65,7 @@ std::vector<std::filesystem::path> DirectoryOpen() {
   } else {
     spdlog::error("Error: %s", NFD::GetError());
   }
+  std::sort(results.begin(), results.end());
   return results;
 }
 

--- a/xpano/gui/panels/sidebar.cc
+++ b/xpano/gui/panels/sidebar.cc
@@ -55,7 +55,8 @@ Action DrawFileMenu() {
   return action;
 }
 
-Action DrawOptionsMenu(algorithm::CompressionOptions* compression_options) {
+Action DrawOptionsMenu(algorithm::CompressionOptions* compression_options,
+                       algorithm::MatchingOptions* matching_options) {
   Action action{};
   if (ImGui::BeginMenu("Options")) {
     if (ImGui::BeginMenu("Export compression")) {
@@ -66,6 +67,16 @@ Action DrawOptionsMenu(algorithm::CompressionOptions* compression_options) {
       ImGui::Checkbox("JPEG optimize", &compression_options->jpeg_optimize);
       ImGui::SliderInt("PNG compression", &compression_options->png_compression,
                        0, kMaxPngCompression);
+      ImGui::EndMenu();
+    }
+    if (ImGui::BeginMenu("Panorama detection")) {
+      ImGui::SliderInt("Matching distance",
+                       &matching_options->neighborhood_search_size, 0, 10);
+      ImGui::SameLine();
+      utils::imgui::InfoMarker(
+          "(?)",
+          "Select how many neighboring images will be considered for panorama "
+          "auto detection.");
       ImGui::EndMenu();
     }
     ImGui::EndMenu();
@@ -190,11 +201,12 @@ Action DrawPanosMenu(const std::vector<algorithm::Pano>& panos,
   return action;
 }
 
-Action DrawMenu(algorithm::CompressionOptions* compression_options) {
+Action DrawMenu(algorithm::CompressionOptions* compression_options,
+                algorithm::MatchingOptions* matching_options) {
   Action action{};
   if (ImGui::BeginMenuBar()) {
     action |= DrawFileMenu();
-    action |= DrawOptionsMenu(compression_options);
+    action |= DrawOptionsMenu(compression_options, matching_options);
     action |= DrawHelpMenu();
     ImGui::EndMenuBar();
   }

--- a/xpano/gui/panels/sidebar.cc
+++ b/xpano/gui/panels/sidebar.cc
@@ -70,6 +70,10 @@ Action DrawOptionsMenu(algorithm::CompressionOptions* compression_options,
       ImGui::EndMenu();
     }
     if (ImGui::BeginMenu("Panorama detection")) {
+      ImGui::Text(
+          "Experiment with this if the app cannot find the panoramas you "
+          "want.");
+      ImGui::Spacing();
       ImGui::SliderInt("Matching distance",
                        &matching_options->neighborhood_search_size, 0,
                        kMaxNeighborhoodSearchSize);
@@ -78,6 +82,13 @@ Action DrawOptionsMenu(algorithm::CompressionOptions* compression_options,
           "(?)",
           "Select how many neighboring images will be considered for panorama "
           "auto detection.");
+      ImGui::SliderInt("Matching threshold", &matching_options->match_threshold,
+                       kMinMatchThreshold, kMaxMatchThreshold);
+      ImGui::SameLine();
+      utils::imgui::InfoMarker(
+          "(?)",
+          "Number of keypoints that need to match in order to include the two "
+          "images in a panorama.");
       ImGui::EndMenu();
     }
     ImGui::EndMenu();

--- a/xpano/gui/panels/sidebar.cc
+++ b/xpano/gui/panels/sidebar.cc
@@ -71,7 +71,8 @@ Action DrawOptionsMenu(algorithm::CompressionOptions* compression_options,
     }
     if (ImGui::BeginMenu("Panorama detection")) {
       ImGui::SliderInt("Matching distance",
-                       &matching_options->neighborhood_search_size, 0, 10);
+                       &matching_options->neighborhood_search_size, 0,
+                       kMaxNeighborhoodSearchSize);
       ImGui::SameLine();
       utils::imgui::InfoMarker(
           "(?)",

--- a/xpano/gui/panels/sidebar.h
+++ b/xpano/gui/panels/sidebar.h
@@ -23,7 +23,8 @@ Action DrawMatchesMenu(const std::vector<algorithm::Match>& matches,
 Action DrawPanosMenu(const std::vector<algorithm::Pano>& panos,
                      const ThumbnailPane& thumbnail_pane, int highlight_id);
 
-Action DrawMenu(algorithm::CompressionOptions* compression_options);
+Action DrawMenu(algorithm::CompressionOptions* compression_options,
+                algorithm::MatchingOptions* matching_options);
 
 void DrawWelcomeText();
 

--- a/xpano/gui/pano_gui.cc
+++ b/xpano/gui/pano_gui.cc
@@ -159,7 +159,7 @@ Action PanoGui::DrawSidebar() {
   Action action{};
   ImGui::Begin("PanoSweep", nullptr,
                ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoScrollbar);
-  action |= DrawMenu(&compression_options_);
+  action |= DrawMenu(&compression_options_, &matching_options_);
 
   DrawWelcomeText();
   ImGui::Separator();
@@ -240,7 +240,8 @@ Action PanoGui::PerformAction(Action action) {
     case ActionType::kOpenFiles: {
       if (auto results = file_dialog::Open(action); !results.empty()) {
         Reset();
-        stitcher_data_future_ = stitcher_pipeline_.RunLoading(results, {}, {});
+        stitcher_data_future_ =
+            stitcher_pipeline_.RunLoading(results, {}, matching_options_);
       }
       break;
     }

--- a/xpano/gui/pano_gui.cc
+++ b/xpano/gui/pano_gui.cc
@@ -240,7 +240,7 @@ Action PanoGui::PerformAction(Action action) {
     case ActionType::kOpenFiles: {
       if (auto results = file_dialog::Open(action); !results.empty()) {
         Reset();
-        stitcher_data_future_ = stitcher_pipeline_.RunLoading(results, {});
+        stitcher_data_future_ = stitcher_pipeline_.RunLoading(results, {}, {});
       }
       break;
     }

--- a/xpano/gui/pano_gui.h
+++ b/xpano/gui/pano_gui.h
@@ -61,6 +61,7 @@ class PanoGui {
   ThumbnailPane thumbnail_pane_;
   algorithm::StitcherPipeline stitcher_pipeline_;
   algorithm::CompressionOptions compression_options_;
+  algorithm::MatchingOptions matching_options_;
 
   std::future<algorithm::StitcherData> stitcher_data_future_;
   std::optional<algorithm::StitcherData> stitcher_data_;

--- a/xpano/utils/disjoint_set.cc
+++ b/xpano/utils/disjoint_set.cc
@@ -1,6 +1,7 @@
 #include "utils/disjoint_set.h"
 
 #include <numeric>
+#include <utility>
 
 namespace xpano::utils {
 

--- a/xpano/utils/disjoint_set.cc
+++ b/xpano/utils/disjoint_set.cc
@@ -4,8 +4,8 @@
 
 namespace xpano::utils {
 
-DisjointSet::DisjointSet(int size) : parent(size), rank(size, 0) {
-  std::iota(parent.begin(), parent.end(), 0);
+DisjointSet::DisjointSet(int size) : parent_(size), rank_(size, 0) {
+  std::iota(parent_.begin(), parent_.end(), 0);
 };
 
 void DisjointSet::Union(int left, int right) {
@@ -16,22 +16,23 @@ void DisjointSet::Union(int left, int right) {
     return;
   }
 
-  if (rank[left] < rank[right]) {
+  if (rank_[left] < rank_[right]) {
     std::swap(left, right);
   }
 
-  parent[right] = left;
+  parent_[right] = left;
 
-  if (rank[left] == rank[right]) {
-    ++rank[left];
+  if (rank_[left] == rank_[right]) {
+    ++rank_[left];
   }
 }
 
-// Path compression
+// Path halving algorithm from
+// https://en.wikipedia.org/wiki/Disjoint-set_data_structure
 int DisjointSet::Find(int element) {
-  if (element != parent[element]) {
-    parent[element] = Find(parent[element]);
-    return parent[element];
+  while (element != parent_[element]) {
+    parent_[element] = parent_[parent_[element]];
+    element = parent_[element];
   }
   return element;
 }

--- a/xpano/utils/disjoint_set.cc
+++ b/xpano/utils/disjoint_set.cc
@@ -1,0 +1,39 @@
+#include "utils/disjoint_set.h"
+
+#include <numeric>
+
+namespace xpano::utils {
+
+DisjointSet::DisjointSet(int size) : parent(size), rank(size, 0) {
+  std::iota(parent.begin(), parent.end(), 0);
+};
+
+void DisjointSet::Union(int left, int right) {
+  left = Find(left);
+  right = Find(right);
+
+  if (left == right) {
+    return;
+  }
+
+  if (rank[left] < rank[right]) {
+    std::swap(left, right);
+  }
+
+  parent[right] = left;
+
+  if (rank[left] == rank[right]) {
+    ++rank[left];
+  }
+}
+
+// Path compression
+int DisjointSet::Find(int element) {
+  if (element != parent[element]) {
+    parent[element] = Find(parent[element]);
+    return parent[element];
+  }
+  return element;
+}
+
+}  // namespace xpano::utils

--- a/xpano/utils/disjoint_set.h
+++ b/xpano/utils/disjoint_set.h
@@ -4,13 +4,13 @@ namespace xpano::utils {
 
 class DisjointSet {
  public:
-  DisjointSet(int size);
+  explicit DisjointSet(int size);
   void Union(int left, int right);
   int Find(int element);
 
  private:
-  std::vector<int> parent;
-  std::vector<int> rank;
+  std::vector<int> parent_;
+  std::vector<int> rank_;
 };
 
 }  // namespace xpano::utils

--- a/xpano/utils/disjoint_set.h
+++ b/xpano/utils/disjoint_set.h
@@ -1,0 +1,16 @@
+#include <vector>
+
+namespace xpano::utils {
+
+class DisjointSet {
+ public:
+  DisjointSet(int size);
+  void Union(int left, int right);
+  int Find(int element);
+
+ private:
+  std::vector<int> parent;
+  std::vector<int> rank;
+};
+
+}  // namespace xpano::utils

--- a/xpano/utils/text.cc
+++ b/xpano/utils/text.cc
@@ -44,6 +44,8 @@ std::vector<Text> LoadTexts(const std::string& executable_path,
       texts.emplace_back(std::move(*text));
     }
   }
+  std::sort(texts.begin(), texts.end(),
+            [](const Text& a, const Text& b) { return a.name < b.name; });
   return texts;
 }
 

--- a/xpano/utils/text.cc
+++ b/xpano/utils/text.cc
@@ -44,8 +44,9 @@ std::vector<Text> LoadTexts(const std::string& executable_path,
       texts.emplace_back(std::move(*text));
     }
   }
-  std::sort(texts.begin(), texts.end(),
-            [](const Text& a, const Text& b) { return a.name < b.name; });
+  std::sort(texts.begin(), texts.end(), [](const Text& lhs, const Text& rhs) {
+    return lhs.name < rhs.name;
+  });
   return texts;
 }
 

--- a/xpano/utils/text.cc
+++ b/xpano/utils/text.cc
@@ -1,5 +1,6 @@
 #include "utils/text.h"
 
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <optional>


### PR DESCRIPTION
Closes #15 

Exposes two options in gui:
- matching distance: "Select how many neighboring images will be considered for panorama auto detection"
- matching threshold: "Number of keypoints that need to match in order to include the two images in a panorama"

`FindPano` algorithm switched to a generic connected components search using `DisjointSet`