### PR TITLE
Feature linux scaling

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -38,7 +38,7 @@ jobs:
         git clone https://github.com/catchorg/Catch2.git catch --depth 1 --branch $CATCH_VERSION
         cd catch
         cmake -B build -DCMAKE_INSTALL_PREFIX=install -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_TESTING=OFF
-        cmake --build build --target install
+        cmake --build build -j $(nproc) --target install
         cd ..
 
     - name: Configure CMake

--- a/misc/build/build-ubuntu-22.04.sh
+++ b/misc/build/build-ubuntu-22.04.sh
@@ -2,6 +2,7 @@
 
 export BUILD_TYPE='Release'
 export CATCH_VERSION='v3.1.0'
+export SDL_VERSION='release-2.24.0'
 
 git submodule update --init
 
@@ -9,14 +10,24 @@ git submodule update --init
 git clone https://github.com/catchorg/Catch2.git catch --depth 1 --branch $CATCH_VERSION
 cd catch
 cmake -B build -DCMAKE_INSTALL_PREFIX=install -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_TESTING=OFF
-cmake --build build --target install
+cmake --build build -j $(nproc) --target install
+cd ..
+
+git clone https://github.com/libsdl-org/SDL.git --depth 1 --branch $SDL_VERSION
+cd SDL
+cmake -B build \
+  -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+  -DCMAKE_INSTALL_PREFIX=install \
+  -DSDL_MISC=OFF
+cmake --build build -j $(nproc) --target install
 cd ..
 
 cmake -B build \
   -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
   -DCMAKE_INSTALL_PREFIX=install \
   -DBUILD_TESTING=ON \
-  -DCatch2_DIR=../catch/install/lib/cmake/Catch2
+  -DCatch2_DIR="../catch/install/lib/cmake/Catch2" \
+  -DSDL2_DIR="SDL/install/lib/cmake/SDL2"
 
 cmake --build build -j $(nproc) --target install
 cd build

--- a/misc/build/build-ubuntu-22.04.sh
+++ b/misc/build/build-ubuntu-22.04.sh
@@ -2,7 +2,6 @@
 
 export BUILD_TYPE='Release'
 export CATCH_VERSION='v3.1.0'
-export SDL_VERSION='release-2.24.0'
 
 git submodule update --init
 
@@ -13,21 +12,11 @@ cmake -B build -DCMAKE_INSTALL_PREFIX=install -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DB
 cmake --build build -j $(nproc) --target install
 cd ..
 
-git clone https://github.com/libsdl-org/SDL.git --depth 1 --branch $SDL_VERSION
-cd SDL
-cmake -B build \
-  -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-  -DCMAKE_INSTALL_PREFIX=install \
-  -DSDL_MISC=OFF
-cmake --build build -j $(nproc) --target install
-cd ..
-
 cmake -B build \
   -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
   -DCMAKE_INSTALL_PREFIX=install \
   -DBUILD_TESTING=ON \
-  -DCatch2_DIR="../catch/install/lib/cmake/Catch2" \
-  -DSDL2_DIR="SDL/install/lib/cmake/SDL2"
+  -DCatch2_DIR=../catch/install/lib/cmake/Catch2
 
 cmake --build build -j $(nproc) --target install
 cd build

--- a/xpano/algorithm/algorithm.cc
+++ b/xpano/algorithm/algorithm.cc
@@ -14,7 +14,6 @@
 #include <opencv2/stitching.hpp>
 
 #include "algorithm/image.h"
-#include "constants.h"
 #include "utils/disjoint_set.h"
 
 namespace xpano::algorithm {

--- a/xpano/gui/backends/sdl.cc
+++ b/xpano/gui/backends/sdl.cc
@@ -19,8 +19,6 @@ Sdl::Sdl(SDL_Renderer *renderer) : renderer_(renderer) {
   } else {
     spdlog::error("Failed to get SDL_RendererInfo: {}", SDL_GetError());
   }
-  const char *video_driver = SDL_GetCurrentVideoDriver();
-  spdlog::info("Video driver: {}", video_driver);
 }
 
 Texture Sdl::CreateTexture(utils::Vec2i size) {

--- a/xpano/gui/backends/sdl.cc
+++ b/xpano/gui/backends/sdl.cc
@@ -11,8 +11,7 @@
 
 namespace xpano::gui::backends {
 
-Sdl::Sdl(SDL_Renderer *renderer, SDL_Window *window)
-    : renderer_(renderer), window_(window) {
+Sdl::Sdl(SDL_Renderer *renderer) : renderer_(renderer) {
   if (SDL_GetRendererInfo(renderer, &info_) == 0) {
     spdlog::info("Current SDL_Renderer: {}", info_.name);
     spdlog::info("Max tex width: {}", info_.max_texture_width);
@@ -20,46 +19,8 @@ Sdl::Sdl(SDL_Renderer *renderer, SDL_Window *window)
   } else {
     spdlog::error("Failed to get SDL_RendererInfo: {}", SDL_GetError());
   }
-  int num_displays = SDL_GetNumVideoDisplays();
-  for (int i = 0; i < num_displays; i++) {
-    float dpi;
-    SDL_GetDisplayDPI(i, &dpi, nullptr, nullptr);
-    spdlog::info("Display {}, dpi = {}", i, dpi);
-
-    int num_modes = SDL_GetNumDisplayModes(i);
-    for (int j = 0; j < num_modes; j++) {
-      SDL_DisplayMode mode;
-      if (SDL_GetDisplayMode(i, j, &mode) == 0) {
-        spdlog::info("Display {}, mode {}, {}x{}@{}, {}", i, j, mode.w, mode.h,
-                     mode.refresh_rate, SDL_GetPixelFormatName(mode.format));
-      }
-    }
-  }
-  SDL_DisplayMode mode;
-  if (SDL_GetWindowDisplayMode(window, &mode) == 0) {
-    spdlog::info("Selected mode, {}x{}@{}, {}", mode.w, mode.h,
-                 mode.refresh_rate, SDL_GetPixelFormatName(mode.format));
-  }
-
-  int num_drivers = SDL_GetNumVideoDrivers();
-  for (int i = 0; i < num_drivers; i++) {
-    const char *video_driver = SDL_GetVideoDriver(i);
-    spdlog::info("Video driver {}: {}", i, video_driver);
-  }
   const char *video_driver = SDL_GetCurrentVideoDriver();
-  spdlog::info("Selected: {}", video_driver);
-
-  int rw, rh;
-  SDL_GetRendererOutputSize(renderer, &rw, &rh);
-
-  int ww, wh;
-  SDL_GL_GetDrawableSize(window, &ww, &wh);
-
-  int w, h;
-  SDL_GetWindowSize(window, &w, &h);
-  spdlog::info("Renderer: {}x{}", rw, rh);
-  spdlog::info("GL Window: {}x{}", ww, wh);
-  spdlog::info("Window: {}x{}", w, h);
+  spdlog::info("Video driver: {}", video_driver);
 }
 
 Texture Sdl::CreateTexture(utils::Vec2i size) {

--- a/xpano/gui/backends/sdl.h
+++ b/xpano/gui/backends/sdl.h
@@ -11,7 +11,7 @@ namespace xpano::gui::backends {
 
 class Sdl final : public Base {
  public:
-  explicit Sdl(SDL_Renderer* renderer);
+  explicit Sdl(SDL_Renderer* renderer, SDL_Window* window);
 
   Texture CreateTexture(utils::Vec2i size) override;
   void UpdateTexture(ImTextureID tex, cv::Mat image) override;
@@ -19,6 +19,7 @@ class Sdl final : public Base {
 
  private:
   SDL_Renderer* renderer_;
+  SDL_Window* window_;
   SDL_RendererInfo info_;
 };
 

--- a/xpano/gui/backends/sdl.h
+++ b/xpano/gui/backends/sdl.h
@@ -11,7 +11,7 @@ namespace xpano::gui::backends {
 
 class Sdl final : public Base {
  public:
-  explicit Sdl(SDL_Renderer* renderer, SDL_Window* window);
+  explicit Sdl(SDL_Renderer* renderer);
 
   Texture CreateTexture(utils::Vec2i size) override;
   void UpdateTexture(ImTextureID tex, cv::Mat image) override;
@@ -19,7 +19,6 @@ class Sdl final : public Base {
 
  private:
   SDL_Renderer* renderer_;
-  SDL_Window* window_;
   SDL_RendererInfo info_;
 };
 

--- a/xpano/gui/pano_gui.cc
+++ b/xpano/gui/pano_gui.cc
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <future>
 #include <optional>
-#include <ostream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/xpano/gui/shortcut.cc
+++ b/xpano/gui/shortcut.cc
@@ -1,5 +1,7 @@
 #include "gui/shortcut.h"
 
+#include <imgui.h>
+
 namespace xpano::gui {
 
 const char* Label(ShortcutType type) {

--- a/xpano/gui/shortcut.h
+++ b/xpano/gui/shortcut.h
@@ -1,6 +1,3 @@
-
-#include <imgui.h>
-
 #include "gui/action.h"
 
 namespace xpano::gui {

--- a/xpano/main.cc
+++ b/xpano/main.cc
@@ -43,6 +43,8 @@
 #endif
 
 int main(int /*unused*/, char** argv) {
+  SDL_SetHint(SDL_HINT_VIDEODRIVER, "wayland,x11");
+
 #if SDL_VERSION_ATLEAST(2, 23, 1)
   SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "permonitorv2");
   // This feature isn't compatible with ImGui as of v1.88
@@ -107,7 +109,7 @@ int main(int /*unused*/, char** argv) {
   const SDL_Color clear_color{114, 140, 165, 255};
 
   // Application specific
-  auto backend = xpano::gui::backends::Sdl{renderer};
+  auto backend = xpano::gui::backends::Sdl{renderer, window};
 
   std::future<xpano::utils::Texts> license_texts =
       std::async(std::launch::async, xpano::utils::LoadTexts, argv[0],

--- a/xpano/main.cc
+++ b/xpano/main.cc
@@ -54,6 +54,8 @@ int main(int /*unused*/, char** argv) {
   // SDL_SetHint(SDL_HINT_WINDOWS_DPI_SCALING, "1");
 #endif
 
+  bool has_wayland_support = (SDL_VideoInit("wayland") == 0);
+
   if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER) != 0) {
     printf("Error: %s\n", SDL_GetError());
     return -1;
@@ -120,7 +122,9 @@ int main(int /*unused*/, char** argv) {
 
   xpano::gui::PanoGui gui(&backend, &logger, std::move(license_texts));
 
-  xpano::utils::sdl::DpiHandler dpi_handler(window);
+  auto window_manager =
+      xpano::utils::sdl::DetermineWindowManager(has_wayland_support);
+  xpano::utils::sdl::DpiHandler dpi_handler(window, window_manager);
   xpano::utils::imgui::FontLoader font_loader(xpano::kFontPath,
                                               xpano::kSymbolsFontPath);
   if (!font_loader.Init(argv[0])) {

--- a/xpano/main.cc
+++ b/xpano/main.cc
@@ -43,7 +43,10 @@
 #endif
 
 int main(int /*unused*/, char** argv) {
+#if SDL_VERSION_ATLEAST(2, 0, 22)
+  // Wayland provides non-blurry app scaling
   SDL_SetHint(SDL_HINT_VIDEODRIVER, "wayland,x11");
+#endif
 
 #if SDL_VERSION_ATLEAST(2, 23, 1)
   SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "permonitorv2");
@@ -109,7 +112,7 @@ int main(int /*unused*/, char** argv) {
   const SDL_Color clear_color{114, 140, 165, 255};
 
   // Application specific
-  auto backend = xpano::gui::backends::Sdl{renderer, window};
+  auto backend = xpano::gui::backends::Sdl{renderer};
 
   std::future<xpano::utils::Texts> license_texts =
       std::async(std::launch::async, xpano::utils::LoadTexts, argv[0],

--- a/xpano/main.cc
+++ b/xpano/main.cc
@@ -43,11 +43,6 @@
 #endif
 
 int main(int /*unused*/, char** argv) {
-#if SDL_VERSION_ATLEAST(2, 0, 22)
-  // Wayland provides non-blurry app scaling
-  SDL_SetHint(SDL_HINT_VIDEODRIVER, "wayland,x11");
-#endif
-
 #if SDL_VERSION_ATLEAST(2, 23, 1)
   SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "permonitorv2");
   // This feature isn't compatible with ImGui as of v1.88
@@ -55,6 +50,13 @@ int main(int /*unused*/, char** argv) {
 #endif
 
   bool has_wayland_support = (SDL_VideoInit("wayland") == 0);
+
+#if SDL_VERSION_ATLEAST(2, 0, 22)
+  // Prefer Wayland as it provides non-blurry fractional scaling
+  if (has_wayland_support) {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "wayland,x11");
+  }
+#endif
 
   if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER) != 0) {
     printf("Error: %s\n", SDL_GetError());

--- a/xpano/utils/sdl_.cc
+++ b/xpano/utils/sdl_.cc
@@ -31,7 +31,7 @@ float DpiHandler::DpiScale() const { return dpi_scale_; }
 
 float DpiHandler::QueryDpiScale() const {
   // DPI values returned on Linux are unreliable, compute framebuffer scaling
-  // instead
+  // instead: https://wiki.libsdl.org/SDL_GetDisplayDPI
   if (running_on_linux_) {
     int width, height;
     int display_width, display_height;

--- a/xpano/utils/sdl_.cc
+++ b/xpano/utils/sdl_.cc
@@ -12,11 +12,39 @@
 
 namespace xpano::utils::sdl {
 
-DpiHandler::DpiHandler(SDL_Window* window) : window_(window) {
+WindowManager DetermineWindowManager(bool wayland_supported) {
+#ifdef _WIN32
+  spdlog::info("WM: Windows");
+  return WindowManager::kWindows;
+#endif
+#ifdef __APPLE__
+  spdlog::info("WM: MacOS");
+  return WindowManager::kMacOS;
+#endif
   const char* video_driver = SDL_GetCurrentVideoDriver();
-  running_on_linux_ = (std::strcmp(video_driver, "wayland") == 0) ||
-                      (std::strcmp(video_driver, "x11") == 0);
+  if (std::strcmp(video_driver, "wayland") == 0) {
+    spdlog::info("WM: Wayland");
+    return WindowManager::kWayland;
+  }
+  if (std::strcmp(video_driver, "x11") == 0) {
+    if (wayland_supported) {
+      spdlog::info("WM: XWayland");
+      spdlog::warn(
+          "XWayland doesn't support sharp fractional scaling\nSwitch to "
+          "Wayland by running \"export "
+          "SDL_VIDEODRIVER=wayland\"");
+      return WindowManager::kXWayland;
+    } else {
+      spdlog::info("WM: x11");
+      return WindowManager::kX11;
+    }
+  }
+  spdlog::info("WM: GenericLinux: {}", video_driver);
+  return WindowManager::kGenericLinux;
 }
+
+DpiHandler::DpiHandler(SDL_Window* window, WindowManager window_manager)
+    : window_(window), window_manager_(window_manager) {}
 
 bool DpiHandler::DpiChanged() {
   if (float dpi_scale = QueryDpiScale(); dpi_scale != dpi_scale_) {
@@ -30,19 +58,51 @@ bool DpiHandler::DpiChanged() {
 float DpiHandler::DpiScale() const { return dpi_scale_; }
 
 float DpiHandler::QueryDpiScale() const {
-  // DPI values returned on Linux are unreliable, compute framebuffer scaling
-  // instead: https://wiki.libsdl.org/SDL_GetDisplayDPI
-  if (running_on_linux_) {
-    int width, height;
-    int display_width, display_height;
-    SDL_GetWindowSize(window_, &width, &height);
-    SDL_GL_GetDrawableSize(window_, &display_width, &display_height);
-    return static_cast<float>(display_width) / static_cast<float>(width);
-  } else {
-    float dpi;
-    SDL_GetDisplayDPI(SDL_GetWindowDisplayIndex(window_), &dpi, nullptr,
-                      nullptr);
-    return dpi / 96.0f;
+  switch (window_manager_) {
+    case WindowManager::kWindows:
+      [[fallthrough]];
+    case WindowManager::kMacOS: {
+      float dpi;
+      SDL_GetDisplayDPI(SDL_GetWindowDisplayIndex(window_), &dpi, nullptr,
+                        nullptr);
+      return dpi / 96.0f;
+    }
+    // Wayland supports sharp fractional scaling, use framebuffer scale
+    // instead of unreliable https://wiki.libsdl.org/SDL_GetDisplayDPI
+    case WindowManager::kWayland: {
+      int width, height;
+      int display_width, display_height;
+      SDL_GetWindowSize(window_, &width, &height);
+      SDL_GL_GetDrawableSize(window_, &display_width, &display_height);
+      return static_cast<float>(display_width) / static_cast<float>(width);
+    }
+    case WindowManager::kGenericLinux:
+      [[fallthrough]];
+    case WindowManager::kXWayland:
+      [[fallthrough]];
+    case WindowManager::kX11: {
+#if SDL_VERSION_ATLEAST(2, 24, 0)
+      // https://github.com/libsdl-org/SDL/issues/5764 changed the GetDisplayDPI
+      // logic, this is a hack to get consistent scaling factor. This code
+      // shouldn't be triggered often as we prefer to run in Wayland.
+      float max_dpi = 96.0f;
+      int num_displays = SDL_GetNumVideoDisplays();
+      for (int i = 0; i < num_displays; i++) {
+        float dpi;
+        SDL_GetDisplayDPI(i, &dpi, nullptr, nullptr);
+        max_dpi = std::max(max_dpi, dpi);
+      }
+      return max_dpi / 96.0f;
+#else
+      float hdpi;  // Gets the result of X11_XGetDefault(disp, "Xft", "dpi"),
+                   // which is a multiple of 96
+      SDL_GetDisplayDPI(SDL_GetWindowDisplayIndex(window_), nullptr, &hdpi,
+                        nullptr);
+      return hdpi / 96.0f;
+#endif
+    }
+    default:
+      return 1.0f;
   }
 }
 

--- a/xpano/utils/sdl_.cc
+++ b/xpano/utils/sdl_.cc
@@ -34,10 +34,9 @@ WindowManager DetermineWindowManager(bool wayland_supported) {
           "Wayland by running \"export "
           "SDL_VIDEODRIVER=wayland\"");
       return WindowManager::kXWayland;
-    } else {
-      spdlog::info("WM: x11");
-      return WindowManager::kX11;
     }
+    spdlog::info("WM: x11");
+    return WindowManager::kX11;
   }
   spdlog::info("WM: GenericLinux: {}", video_driver);
   return WindowManager::kGenericLinux;
@@ -57,6 +56,8 @@ bool DpiHandler::DpiChanged() {
 
 float DpiHandler::DpiScale() const { return dpi_scale_; }
 
+// NOLINTBEGIN(bugprone-branch-clone): doesn't work with [[fallthrough]]
+
 float DpiHandler::QueryDpiScale() const {
   switch (window_manager_) {
     case WindowManager::kWindows:
@@ -70,8 +71,10 @@ float DpiHandler::QueryDpiScale() const {
     // Wayland supports sharp fractional scaling, use framebuffer scale
     // instead of unreliable https://wiki.libsdl.org/SDL_GetDisplayDPI
     case WindowManager::kWayland: {
-      int width, height;
-      int display_width, display_height;
+      int width;
+      int height;
+      int display_width;
+      int display_height;
       SDL_GetWindowSize(window_, &width, &height);
       SDL_GL_GetDrawableSize(window_, &display_width, &display_height);
       return static_cast<float>(display_width) / static_cast<float>(width);
@@ -105,6 +108,8 @@ float DpiHandler::QueryDpiScale() const {
       return 1.0f;
   }
 }
+
+// NOLINTEND(bugprone-branch-clone)
 
 std::optional<std::filesystem::path> InitializePrefPath() {
   auto sdl_pref_path = std::unique_ptr<char, decltype(&SDL_free)>(

--- a/xpano/utils/sdl_.cc
+++ b/xpano/utils/sdl_.cc
@@ -1,20 +1,27 @@
 #include "utils/sdl_.h"
 
+#include <cstring>
 #include <filesystem>
 #include <memory>
 #include <optional>
 
 #include <SDL.h>
+#include <spdlog/spdlog.h>
 
 #include "constants.h"
 
 namespace xpano::utils::sdl {
 
-DpiHandler::DpiHandler(SDL_Window* window) : window_(window) {}
+DpiHandler::DpiHandler(SDL_Window* window) : window_(window) {
+  const char* video_driver = SDL_GetCurrentVideoDriver();
+  linux_ = (std::strcmp(video_driver, "wayland") == 0) ||
+           (std::strcmp(video_driver, "x11") == 0);
+}
 
 bool DpiHandler::DpiChanged() {
   if (float dpi_scale = QueryDpiScale(); dpi_scale != dpi_scale_) {
     dpi_scale_ = dpi_scale;
+    spdlog::info("Loading at {}", dpi_scale);
     return true;
   }
   return false;
@@ -23,9 +30,18 @@ bool DpiHandler::DpiChanged() {
 float DpiHandler::DpiScale() const { return dpi_scale_; }
 
 float DpiHandler::QueryDpiScale() const {
-  float dpi;
-  SDL_GetDisplayDPI(SDL_GetWindowDisplayIndex(window_), &dpi, nullptr, nullptr);
-  return dpi / 96.0f;
+  if (linux_) {
+    int width, height;
+    int display_width, display_height;
+    SDL_GetWindowSize(window_, &width, &height);
+    SDL_GL_GetDrawableSize(window_, &display_width, &display_height);
+    return static_cast<float>(display_width) / static_cast<float>(width);
+  } else {
+    float dpi;
+    SDL_GetDisplayDPI(SDL_GetWindowDisplayIndex(window_), &dpi, nullptr,
+                      nullptr);
+    return dpi / 96.0f;
+  }
 }
 
 std::optional<std::filesystem::path> InitializePrefPath() {

--- a/xpano/utils/sdl_.cc
+++ b/xpano/utils/sdl_.cc
@@ -14,14 +14,14 @@ namespace xpano::utils::sdl {
 
 DpiHandler::DpiHandler(SDL_Window* window) : window_(window) {
   const char* video_driver = SDL_GetCurrentVideoDriver();
-  linux_ = (std::strcmp(video_driver, "wayland") == 0) ||
-           (std::strcmp(video_driver, "x11") == 0);
+  running_on_linux_ = (std::strcmp(video_driver, "wayland") == 0) ||
+                      (std::strcmp(video_driver, "x11") == 0);
 }
 
 bool DpiHandler::DpiChanged() {
   if (float dpi_scale = QueryDpiScale(); dpi_scale != dpi_scale_) {
     dpi_scale_ = dpi_scale;
-    spdlog::info("Loading at {}", dpi_scale);
+    spdlog::info("Loading fonts at {}x scale", dpi_scale);
     return true;
   }
   return false;
@@ -30,7 +30,9 @@ bool DpiHandler::DpiChanged() {
 float DpiHandler::DpiScale() const { return dpi_scale_; }
 
 float DpiHandler::QueryDpiScale() const {
-  if (linux_) {
+  // DPI values returned on Linux are unreliable, compute framebuffer scaling
+  // instead
+  if (running_on_linux_) {
     int width, height;
     int display_width, display_height;
     SDL_GetWindowSize(window_, &width, &height);

--- a/xpano/utils/sdl_.h
+++ b/xpano/utils/sdl_.h
@@ -7,9 +7,20 @@
 
 namespace xpano::utils::sdl {
 
+enum class WindowManager {
+  kWindows,
+  kMacOS,
+  kX11,
+  kWayland,
+  kXWayland,
+  kGenericLinux
+};
+
+WindowManager DetermineWindowManager(bool wayland_supported);
+
 class DpiHandler {
  public:
-  explicit DpiHandler(SDL_Window* window);
+  explicit DpiHandler(SDL_Window* window, WindowManager window_manager);
 
   bool DpiChanged();
   [[nodiscard]] float DpiScale() const;
@@ -18,8 +29,8 @@ class DpiHandler {
   [[nodiscard]] float QueryDpiScale() const;
 
   SDL_Window* window_;
+  WindowManager window_manager_;
   float dpi_scale_ = 0.0f;
-  bool running_on_linux_ = false;
 };
 
 std::optional<std::filesystem::path> InitializePrefPath();

--- a/xpano/utils/sdl_.h
+++ b/xpano/utils/sdl_.h
@@ -19,6 +19,7 @@ class DpiHandler {
 
   SDL_Window* window_;
   float dpi_scale_ = 0.0f;
+  bool linux_ = false;
 };
 
 std::optional<std::filesystem::path> InitializePrefPath();

--- a/xpano/utils/sdl_.h
+++ b/xpano/utils/sdl_.h
@@ -19,7 +19,7 @@ class DpiHandler {
 
   SDL_Window* window_;
   float dpi_scale_ = 0.0f;
-  bool linux_ = false;
+  bool running_on_linux_ = false;
 };
 
 std::optional<std::filesystem::path> InitializePrefPath();


### PR DESCRIPTION
Support multi-monitor setups with different scaling on Linux.

Fractional scaling is blurry on XWayland, which is unfortunately the default with SDL apps on Ubuntu 22.04 as of now.

User can switch to Wayland by running `export SDL_VIDEODRIVER=wayland`.

Determining the size at which to load the fonts is tricky as X11 / Wayland approach scaling differently:
 - Wayland works more like MacOS, with having framebuffer size > window size, however it returns unusable DPI values from https://wiki.libsdl.org/SDL_GetDisplayDPI (see the warning there), so we use the framebuffer/window size ratio instead
 - X11 has framebuffer size == window size and the returned DPI values can be used to determine font size, but only until SDL 2.24.0: https://github.com/libsdl-org/SDL/issues/5764