### PR TITLE
Fix asset loading when the exe is run from PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ if (WIN32)
   set(CMAKE_INSTALL_DATADIR ".")
 else()
   set(CMAKE_INSTALL_BINDIR "bin")
-  set(CMAKE_INSTALL_DATADIR "share")
+  set(CMAKE_INSTALL_DATADIR "share/xpano")
 endif()
 
 install(TARGETS

--- a/xpano/utils/imgui_.cc
+++ b/xpano/utils/imgui_.cc
@@ -29,7 +29,7 @@ void FontLoader::ComputeGlyphRanges() {
   builder.BuildRanges(&symbol_ranges_);
 }
 
-bool FontLoader::Init(const std::string& executable_path) {
+bool FontLoader::Init(const std::filesystem::path& executable_path) {
   ComputeGlyphRanges();
 
   if (auto font = resource::Find(executable_path, alphabet_font_path_); font) {

--- a/xpano/utils/imgui_.h
+++ b/xpano/utils/imgui_.h
@@ -11,7 +11,7 @@ namespace xpano::utils::imgui {
 class FontLoader {
  public:
   FontLoader(std::string alphabet_font_path, std::string symbols_font_path);
-  bool Init(const std::string& executable_path);
+  bool Init(const std::filesystem::path& executable_path);
   void Reload(float scale);
 
  private:

--- a/xpano/utils/resource.cc
+++ b/xpano/utils/resource.cc
@@ -11,17 +11,15 @@
 
 namespace xpano::utils::resource {
 
-std::optional<std::string> Find(const std::string& executable_path,
+std::optional<std::string> Find(const std::filesystem::path& executable_path,
                                 const std::string& rel_path) {
-  std::filesystem::path base =
-      std::filesystem::path(executable_path).parent_path();
-  auto path = base / rel_path;
+  auto path = executable_path / rel_path;
   if (std::filesystem::exists(path)) {
     return path.string();
   }
 
-  const auto linux_prefix = std::filesystem::path("../share");
-  auto linux_path = base / linux_prefix / rel_path;
+  const auto linux_prefix = std::filesystem::path("../share/xpano");
+  auto linux_path = executable_path / linux_prefix / rel_path;
   if (std::filesystem::exists(linux_path)) {
     return linux_path.string();
   }
@@ -30,7 +28,7 @@ std::optional<std::string> Find(const std::string& executable_path,
   return {};
 }
 
-SdlSurface LoadIcon(const std::string& executable_path,
+SdlSurface LoadIcon(const std::filesystem::path& executable_path,
                     const std::string& path) {
   auto full_path = Find(executable_path, path);
   if (!full_path) {

--- a/xpano/utils/resource.h
+++ b/xpano/utils/resource.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <filesystem>
 #include <memory>
 #include <optional>
 #include <string>
@@ -8,12 +9,12 @@
 
 namespace xpano::utils::resource {
 
-std::optional<std::string> Find(const std::string& executable_path,
+std::optional<std::string> Find(const std::filesystem::path& executable_path,
                                 const std::string& rel_path);
 
 using SdlSurface = std::unique_ptr<SDL_Surface, decltype(&SDL_FreeSurface)>;
 
-SdlSurface LoadIcon(const std::string& executable_path,
+SdlSurface LoadIcon(const std::filesystem::path& executable_path,
                     const std::string& rel_path);
 
 }  // namespace xpano::utils::resource

--- a/xpano/utils/sdl_.cc
+++ b/xpano/utils/sdl_.cc
@@ -120,4 +120,13 @@ std::optional<std::filesystem::path> InitializePrefPath() {
   return {sdl_pref_path.get()};
 }
 
+std::optional<std::filesystem::path> InitializeBasePath() {
+  auto sdl_base_path =
+      std::unique_ptr<char, decltype(&SDL_free)>(SDL_GetBasePath(), &SDL_free);
+  if (!sdl_base_path) {
+    return {};
+  }
+  return {sdl_base_path.get()};
+}
+
 }  // namespace xpano::utils::sdl

--- a/xpano/utils/sdl_.h
+++ b/xpano/utils/sdl_.h
@@ -35,4 +35,6 @@ class DpiHandler {
 
 std::optional<std::filesystem::path> InitializePrefPath();
 
+std::optional<std::filesystem::path> InitializeBasePath();
+
 }  // namespace xpano::utils::sdl

--- a/xpano/utils/text.cc
+++ b/xpano/utils/text.cc
@@ -32,7 +32,7 @@ std::optional<Text> LoadText(const std::filesystem::path& path) {
 
 }  // namespace
 
-std::vector<Text> LoadTexts(const std::string& executable_path,
+std::vector<Text> LoadTexts(const std::filesystem::path& executable_path,
                             const std::string& rel_path) {
   auto license_dir = resource::Find(executable_path, rel_path);
   if (!license_dir) {

--- a/xpano/utils/text.h
+++ b/xpano/utils/text.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -10,7 +11,7 @@ struct Text {
   std::vector<std::string> lines;
 };
 
-std::vector<Text> LoadTexts(const std::string& executable_path,
+std::vector<Text> LoadTexts(const std::filesystem::path& executable_path,
                             const std::string& rel_path);
 
 using Texts = std::vector<Text>;


### PR DESCRIPTION
Use [SDL_GetBasePath](https://wiki.libsdl.org/SDL_GetBasePath) instead of `argv[0]`, which didn't work after `sudo make install`.

Also put asset files to share/xpano instead of share, to better support `sudo make install`