### PR TITLE
Feature loading parameters

### DIFF
--- a/xpano/algorithm/image.cc
+++ b/xpano/algorithm/image.cc
@@ -1,5 +1,6 @@
 #include "xpano/algorithm/image.h"
 
+#include <algorithm>
 #include <string>
 #include <utility>
 #include <vector>
@@ -31,8 +32,10 @@ void Image::Load(int preview_longer_side) {
     auto preview_size =
         (full_size.width > full_size.height)
             ? cv::Size(preview_longer_side,
-                       preview_longer_side / full_size.aspectRatio())
-            : cv::Size(preview_longer_side * full_size.aspectRatio(),
+                       static_cast<int>(preview_longer_side /
+                                        full_size.aspectRatio()))
+            : cv::Size(static_cast<int>(preview_longer_side *
+                                        full_size.aspectRatio()),
                        preview_longer_side);
     cv::resize(tmp, preview_, preview_size, 0.0, 0.0, cv::INTER_AREA);
   } else {

--- a/xpano/algorithm/image.cc
+++ b/xpano/algorithm/image.cc
@@ -19,16 +19,29 @@ thread_local cv::Ptr<cv::Feature2D> sift = cv::SIFT::create(kNumFeatures);
 
 Image::Image(std::string path) : path_(std::move(path)) {}
 
-void Image::Load() {
+void Image::Load(int preview_longer_side) {
   cv::Mat tmp = cv::imread(path_);
   if (tmp.empty()) {
     spdlog::error("Failed to load image {}", path_);
     return;
   }
-  cv::resize(tmp, preview_, cv::Size(), 0.5, 0.5, cv::INTER_AREA);
+
+  auto full_size = tmp.size();
+  if (std::max(full_size.width, full_size.height) > preview_longer_side) {
+    auto preview_size =
+        (full_size.width > full_size.height)
+            ? cv::Size(preview_longer_side,
+                       preview_longer_side / full_size.aspectRatio())
+            : cv::Size(preview_longer_side * full_size.aspectRatio(),
+                       preview_longer_side);
+    cv::resize(tmp, preview_, preview_size, 0.0, 0.0, cv::INTER_AREA);
+  } else {
+    preview_ = tmp;
+  }
+
   sift->detectAndCompute(preview_, cv::Mat(), keypoints_, descriptors_);
-  cv::resize(preview_, thumbnail_, cv::Size(kPreviewSize, kPreviewSize), 0, 0,
-             cv::INTER_AREA);
+  cv::resize(preview_, thumbnail_, cv::Size(kThumbnailSize, kThumbnailSize), 0,
+             0, cv::INTER_AREA);
 
   spdlog::info("Loaded {}", path_);
   spdlog::info("Size: {} x {}, Keypoints: {}", preview_.size[1],

--- a/xpano/algorithm/image.h
+++ b/xpano/algorithm/image.h
@@ -12,7 +12,7 @@ class Image {
   Image() = default;
   explicit Image(std::string path);
 
-  void Load();
+  void Load(int preview_longer_side);
 
   [[nodiscard]] cv::Mat GetFullRes() const;
   [[nodiscard]] cv::Mat GetThumbnail() const;

--- a/xpano/algorithm/stitcher_pipeline.h
+++ b/xpano/algorithm/stitcher_pipeline.h
@@ -29,7 +29,7 @@ struct MatchingOptions {
 };
 
 struct LoadingOptions {
-  // int image_downsample_factor = 1;
+  int preview_longer_side = kDefaultPreviewLongerSide;
 };
 
 struct StitchingOptions {
@@ -94,7 +94,7 @@ class StitcherPipeline {
 
  private:
   std::vector<algorithm::Image> RunLoadingPipeline(
-      const std::vector<std::string> &inputs);
+      const std::vector<std::string> &inputs, const LoadingOptions &options);
   StitcherData RunMatchingPipeline(std::vector<algorithm::Image> images,
                                    const MatchingOptions &options);
 

--- a/xpano/constants.h
+++ b/xpano/constants.h
@@ -7,7 +7,7 @@
 namespace xpano {
 
 constexpr int kNumFeatures = 3000;
-constexpr int kPreviewSize = 256;
+constexpr int kThumbnailSize = 256;
 constexpr int kMaxTexSize = 16384;
 constexpr int kLoupeSize = 4096;
 constexpr int kMinMatchThreshold = 4;
@@ -54,5 +54,10 @@ const std::string kIconPath = "assets/icon.png";
 
 constexpr int kDefaultNeighborhoodSearchSize = 2;
 constexpr int kMaxNeighborhoodSearchSize = 10;
+
+constexpr int kDefaultPreviewLongerSide = 1024;
+constexpr int kMinPreviewLongerSide = 512;
+constexpr int kMaxPreviewLongerSide = 2048;
+constexpr int kStepPreviewLongerSide = 256;
 
 }  // namespace xpano

--- a/xpano/gui/panels/sidebar.cc
+++ b/xpano/gui/panels/sidebar.cc
@@ -1,5 +1,6 @@
 #include "xpano/gui/panels/sidebar.h"
 
+#include <algorithm>
 #include <string>
 #include <vector>
 

--- a/xpano/gui/panels/sidebar.cc
+++ b/xpano/gui/panels/sidebar.cc
@@ -57,6 +57,7 @@ Action DrawFileMenu() {
 }
 
 Action DrawOptionsMenu(algorithm::CompressionOptions* compression_options,
+                       algorithm::LoadingOptions* loading_options,
                        algorithm::MatchingOptions* matching_options) {
   Action action{};
   if (ImGui::BeginMenu("Options")) {
@@ -68,6 +69,26 @@ Action DrawOptionsMenu(algorithm::CompressionOptions* compression_options,
       ImGui::Checkbox("JPEG optimize", &compression_options->jpeg_optimize);
       ImGui::SliderInt("PNG compression", &compression_options->png_compression,
                        0, kMaxPngCompression);
+      ImGui::EndMenu();
+    }
+    if (ImGui::BeginMenu("Image loading")) {
+      ImGui::Text(
+          "Modify this for faster image loading / more precision in panorama "
+          "detection.");
+      ImGui::Spacing();
+      if (ImGui::InputInt("Preview size", &loading_options->preview_longer_side,
+                          kStepPreviewLongerSide, kStepPreviewLongerSide)) {
+        loading_options->preview_longer_side = std::max(
+            loading_options->preview_longer_side, kMinPreviewLongerSide);
+        loading_options->preview_longer_side = std::min(
+            loading_options->preview_longer_side, kMaxPreviewLongerSide);
+      }
+      ImGui::SameLine();
+      utils::imgui::InfoMarker(
+          "(?)",
+          "Size of the preview image's longer side in pixels.\n - decrease to "
+          "get faster loading times.\n - increase to get more precision for "
+          "panorama detection.");
       ImGui::EndMenu();
     }
     if (ImGui::BeginMenu("Panorama detection")) {
@@ -220,11 +241,13 @@ Action DrawPanosMenu(const std::vector<algorithm::Pano>& panos,
 }
 
 Action DrawMenu(algorithm::CompressionOptions* compression_options,
+                algorithm::LoadingOptions* loading_options,
                 algorithm::MatchingOptions* matching_options) {
   Action action{};
   if (ImGui::BeginMenuBar()) {
     action |= DrawFileMenu();
-    action |= DrawOptionsMenu(compression_options, matching_options);
+    action |=
+        DrawOptionsMenu(compression_options, loading_options, matching_options);
     action |= DrawHelpMenu();
     ImGui::EndMenuBar();
   }

--- a/xpano/gui/panels/sidebar.h
+++ b/xpano/gui/panels/sidebar.h
@@ -24,6 +24,7 @@ Action DrawPanosMenu(const std::vector<algorithm::Pano>& panos,
                      const ThumbnailPane& thumbnail_pane, int highlight_id);
 
 Action DrawMenu(algorithm::CompressionOptions* compression_options,
+                algorithm::LoadingOptions* loading_options,
                 algorithm::MatchingOptions* matching_options);
 
 void DrawWelcomeText();

--- a/xpano/gui/panels/thumbnail_pane.cc
+++ b/xpano/gui/panels/thumbnail_pane.cc
@@ -88,7 +88,7 @@ ThumbnailPane::ThumbnailPane(backends::Base *backend) : backend_(backend) {}
 void ThumbnailPane::Load(const std::vector<algorithm::Image> &images) {
   spdlog::info("Loading {} thumbnails", images.size());
   int num_images = static_cast<int>(images.size());
-  auto thumbnail_size = utils::Vec2i{kPreviewSize};
+  auto thumbnail_size = utils::Vec2i{kThumbnailSize};
   int side = 0;
   while (side * side < num_images) {
     side++;

--- a/xpano/gui/pano_gui.cc
+++ b/xpano/gui/pano_gui.cc
@@ -146,7 +146,8 @@ Action PanoGui::DrawSidebar() {
   Action action{};
   ImGui::Begin("PanoSweep", nullptr,
                ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoScrollbar);
-  action |= DrawMenu(&compression_options_, &matching_options_);
+  action |=
+      DrawMenu(&compression_options_, &loading_options_, &matching_options_);
 
   DrawWelcomeText();
   ImGui::Separator();
@@ -227,8 +228,8 @@ Action PanoGui::PerformAction(Action action) {
     case ActionType::kOpenFiles: {
       if (auto results = file_dialog::Open(action); !results.empty()) {
         Reset();
-        stitcher_data_future_ =
-            stitcher_pipeline_.RunLoading(results, {}, matching_options_);
+        stitcher_data_future_ = stitcher_pipeline_.RunLoading(
+            results, loading_options_, matching_options_);
       }
       break;
     }

--- a/xpano/gui/pano_gui.h
+++ b/xpano/gui/pano_gui.h
@@ -53,6 +53,7 @@ class PanoGui {
   StatusMessage status_message_;
 
   algorithm::CompressionOptions compression_options_;
+  algorithm::LoadingOptions loading_options_;
   algorithm::MatchingOptions matching_options_;
   std::optional<algorithm::StitcherData> stitcher_data_;
 

--- a/xpano/utils/sdl_.cc
+++ b/xpano/utils/sdl_.cc
@@ -1,5 +1,6 @@
 #include "xpano/utils/sdl_.h"
 
+#include <algorithm>
 #include <cstring>
 #include <filesystem>
 #include <memory>


### PR DESCRIPTION
Progress in #24 

Added option to control the image preview size. 
This affects runtime / memory requirements of the loading step as keypoints / descriptors are computed over the preview images.

Preview size - size of the preview image's longer side in pixels
- decrease to get faster loading times
- increase to get more precision for panorama detection