### PR TITLE
Feature stitcher projections

### DIFF
--- a/misc/mappings/iwyu_win.imp
+++ b/misc/mappings/iwyu_win.imp
@@ -2,6 +2,7 @@
   { include: [ "<xstring>", private, "<string>", public ] },
   { include: [ "<xutility>", private, "<algorithm>", public ] },
   { include: ["@<opencv2/core/.*>", "private", "<opencv2/core.hpp>", "public"] },
+  { include: ["@<opencv2/stitching/.*>", "private", "<opencv2/stitching.hpp>", "public"] },
   { include: ["@<SDL_.*>", "private", "<SDL.h>", "public"] },
   { include: ["<corecrt_math.h>", "private", "<cmath>", "public"] },
   { include: ["<imgui_internal.h>", "public", "<imgui.h>", "public"] },

--- a/xpano/algorithm/algorithm.cc
+++ b/xpano/algorithm/algorithm.cc
@@ -23,6 +23,50 @@ void InsertInOrder(int value, std::vector<int>* vec) {
   auto iter = std::lower_bound(vec->begin(), vec->end(), value);
   vec->insert(iter, value);
 }
+cv::Ptr<cv::WarperCreator> PickWarper(ProjectionOptions options) {
+  cv::Ptr<cv::WarperCreator> warper_creator;
+  switch (options.projection_type) {
+    case ProjectionType::kPerspective:
+      warper_creator = cv::makePtr<cv::PlaneWarper>();
+      break;
+    case ProjectionType::kCylindrical:
+      warper_creator = cv::makePtr<cv::CylindricalWarper>();
+      break;
+    case ProjectionType::kSpherical:
+      warper_creator = cv::makePtr<cv::SphericalWarper>();
+      break;
+    case ProjectionType::kFisheye:
+      warper_creator = cv::makePtr<cv::FisheyeWarper>();
+      break;
+    case ProjectionType::kStereographic:
+      warper_creator = cv::makePtr<cv::StereographicWarper>();
+      break;
+    case ProjectionType::kCompressedRectilinear:
+      warper_creator = cv::makePtr<cv::CompressedRectilinearWarper>(
+          options.a_param, options.b_param);
+      break;
+    case ProjectionType::kCompressedRectilinearPortrait:
+      warper_creator = cv::makePtr<cv::CompressedRectilinearPortraitWarper>(
+          options.a_param, options.b_param);
+      break;
+    case ProjectionType::kPanini:
+      warper_creator =
+          cv::makePtr<cv::PaniniWarper>(options.a_param, options.b_param);
+      break;
+    case ProjectionType::kPaniniPortrait:
+      warper_creator = cv::makePtr<cv::PaniniPortraitWarper>(options.a_param,
+                                                             options.b_param);
+      break;
+    case ProjectionType::kMercator:
+      warper_creator = cv::makePtr<cv::MercatorWarper>();
+      break;
+    case ProjectionType::kTransverseMercator:
+      warper_creator = cv::makePtr<cv::TransverseMercatorWarper>();
+      break;
+  }
+  return warper_creator;
+}
+
 }  // namespace
 
 std::vector<cv::DMatch> MatchImages(const Image& img1, const Image& img2) {
@@ -114,68 +158,14 @@ std::vector<Pano> FindPanos(const std::vector<Match>& matches,
   return result;
 }
 
-/*
-  kPerspective,
-  kCylindrical,
-  kSpherical,
-  kFisheye,
-  kStereographic,
-  kCompressedRectilinear,
-  kCompressedRectilinearPortrait,
-  kPanini,
-  kPaniniPortrait,
-  kMercator,
-  kTransverseMercator
-*/
-
 std::pair<cv::Stitcher::Status, cv::Mat> Stitch(
     const std::vector<cv::Mat>& images, ProjectionOptions options) {
-  cv::Mat out;
   auto stitcher = cv::Stitcher::create(cv::Stitcher::PANORAMA);
-  cv::Ptr<cv::WarperCreator> warper_creator;
-
-  switch (options.projection_type) {
-    case ProjectionType::kPerspective:
-      warper_creator = cv::makePtr<cv::PlaneWarper>();
-      break;
-    case ProjectionType::kCylindrical:
-      warper_creator = cv::makePtr<cv::CylindricalWarper>();
-      break;
-    case ProjectionType::kSpherical:
-      warper_creator = cv::makePtr<cv::SphericalWarper>();
-      break;
-    case ProjectionType::kFisheye:
-      warper_creator = cv::makePtr<cv::FisheyeWarper>();
-      break;
-    case ProjectionType::kStereographic:
-      warper_creator = cv::makePtr<cv::StereographicWarper>();
-      break;
-    case ProjectionType::kCompressedRectilinear:
-      warper_creator = cv::makePtr<cv::CompressedRectilinearWarper>(
-          options.a_param, options.b_param);
-      break;
-    case ProjectionType::kCompressedRectilinearPortrait:
-      warper_creator = cv::makePtr<cv::CompressedRectilinearPortraitWarper>(
-          options.a_param, options.b_param);
-      break;
-    case ProjectionType::kPanini:
-      warper_creator =
-          cv::makePtr<cv::PaniniWarper>(options.a_param, options.b_param);
-      break;
-    case ProjectionType::kPaniniPortrait:
-      warper_creator = cv::makePtr<cv::PaniniPortraitWarper>(options.a_param,
-                                                             options.b_param);
-      break;
-    case ProjectionType::kMercator:
-      warper_creator = cv::makePtr<cv::MercatorWarper>();
-      break;
-    case ProjectionType::kTransverseMercator:
-      warper_creator = cv::makePtr<cv::TransverseMercatorWarper>();
-      break;
-  }
-
+  auto warper_creator = PickWarper(options);
   stitcher->setWarper(warper_creator);
-  cv::Stitcher::Status status = stitcher->stitch(images, out);
+
+  cv::Mat out;
+  auto status = stitcher->stitch(images, out);
 
   if (options.projection_type == ProjectionType::kStereographic) {
     cv::rotate(out, out, cv::ROTATE_90_COUNTERCLOCKWISE);
@@ -203,6 +193,8 @@ std::string ToString(cv::Stitcher::Status& status) {
   }
 }
 
+// NOLINTBEGIN(bugprone-branch-clone): doesn't work with [[fallthrough]]
+
 bool HasAdvancedParameters(ProjectionType projection_type) {
   switch (projection_type) {
     case ProjectionType::kCompressedRectilinear:
@@ -217,6 +209,8 @@ bool HasAdvancedParameters(ProjectionType projection_type) {
       return false;
   }
 }
+
+// NOLINTEND(bugprone-branch-clone)
 
 const char* Label(ProjectionType projection_type) {
   switch (projection_type) {

--- a/xpano/algorithm/algorithm.h
+++ b/xpano/algorithm/algorithm.h
@@ -27,8 +27,46 @@ std::vector<cv::DMatch> MatchImages(const Image& img1, const Image& img2);
 std::vector<Pano> FindPanos(const std::vector<Match>& matches,
                             int match_threshold);
 
+enum class ProjectionType {
+  kPerspective,
+  kCylindrical,
+  kSpherical,
+  kFisheye,
+  kStereographic,
+  kCompressedRectilinear,
+  kCompressedRectilinearPortrait,
+  kPanini,
+  kPaniniPortrait,
+  kMercator,
+  kTransverseMercator
+};
+
+const auto kProjectionTypes =
+    std::array{ProjectionType::kPerspective,
+               ProjectionType::kCylindrical,
+               ProjectionType::kSpherical,
+               ProjectionType::kFisheye,
+               ProjectionType::kStereographic,
+               ProjectionType::kCompressedRectilinear,
+               ProjectionType::kCompressedRectilinearPortrait,
+               ProjectionType::kPanini,
+               ProjectionType::kPaniniPortrait,
+               ProjectionType::kMercator,
+               ProjectionType::kTransverseMercator};
+
+const char* Label(ProjectionType projection_type);
+
+bool HasAdvancedParameters(ProjectionType projection_type);
+
+struct ProjectionOptions {
+  algorithm::ProjectionType projection_type =
+      algorithm::ProjectionType::kSpherical;
+  float a_param = 2.0f;
+  float b_param = 1.0f;
+};
+
 std::pair<cv::Stitcher::Status, cv::Mat> Stitch(
-    const std::vector<cv::Mat>& images);
+    const std::vector<cv::Mat>& images, ProjectionOptions options);
 
 std::string ToString(cv::Stitcher::Status& status);
 

--- a/xpano/algorithm/algorithm.h
+++ b/xpano/algorithm/algorithm.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <string>
 #include <utility>
 #include <vector>
@@ -8,6 +9,7 @@
 #include <opencv2/stitching.hpp>
 
 #include "xpano/algorithm/image.h"
+#include "xpano/constants.h"
 
 namespace xpano::algorithm {
 
@@ -61,8 +63,8 @@ bool HasAdvancedParameters(ProjectionType projection_type);
 struct ProjectionOptions {
   algorithm::ProjectionType projection_type =
       algorithm::ProjectionType::kSpherical;
-  float a_param = 2.0f;
-  float b_param = 1.0f;
+  float a_param = kDefaultPaniniA;
+  float b_param = kDefaultPaniniB;
 };
 
 std::pair<cv::Stitcher::Status, cv::Mat> Stitch(

--- a/xpano/algorithm/stitcher_pipeline.cc
+++ b/xpano/algorithm/stitcher_pipeline.cc
@@ -95,7 +95,7 @@ std::future<StitchingResult> StitcherPipeline::RunStitching(
     }
 
     loading_progress_.SetTaskType(ProgressType::kStitchingPano);
-    auto [status, pano] = Stitch(imgs);
+    auto [status, pano] = Stitch(imgs, options.projection);
     loading_progress_.NotifyTaskDone();
 
     if (status != cv::Stitcher::OK) {

--- a/xpano/algorithm/stitcher_pipeline.h
+++ b/xpano/algorithm/stitcher_pipeline.h
@@ -36,6 +36,7 @@ struct StitchingOptions {
   int pano_id = 0;
   std::optional<std::string> export_path;
   CompressionOptions compression;
+  ProjectionOptions projection;
 };
 
 struct StitcherData {

--- a/xpano/constants.h
+++ b/xpano/constants.h
@@ -60,4 +60,7 @@ constexpr int kMinPreviewLongerSide = 512;
 constexpr int kMaxPreviewLongerSide = 2048;
 constexpr int kStepPreviewLongerSide = 256;
 
+constexpr float kDefaultPaniniA = 2.0f;
+constexpr float kDefaultPaniniB = 1.0f;
+
 }  // namespace xpano

--- a/xpano/gui/action.h
+++ b/xpano/gui/action.h
@@ -14,6 +14,7 @@ enum class ActionType {
   kShowMatch,
   kShowPano,
   kModifyPano,
+  kRecomputePano,
   kQuit,
   kToggleDebugLog
 };

--- a/xpano/gui/backends/sdl.cc
+++ b/xpano/gui/backends/sdl.cc
@@ -26,8 +26,13 @@ Texture Sdl::CreateTexture(utils::Vec2i size) {
     spdlog::error("Texture size {} x {} is too big.", size[0], size[1]);
     return nullptr;
   }
+  const char *old_texture_sampling = SDL_GetHint(SDL_HINT_RENDER_SCALE_QUALITY);
+  SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "best");
   auto *sdl_tex = SDL_CreateTexture(renderer_, SDL_PIXELFORMAT_BGR24,
                                     SDL_TEXTUREACCESS_STATIC, size[0], size[1]);
+  if (old_texture_sampling) {
+    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, old_texture_sampling);
+  }
   if (sdl_tex == nullptr) {
     spdlog::error("Failed to create SDL_Texture: {}", SDL_GetError());
     return nullptr;

--- a/xpano/gui/panels/sidebar.cc
+++ b/xpano/gui/panels/sidebar.cc
@@ -87,8 +87,8 @@ void DrawLoadingOptionsMenu(algorithm::LoadingOptions* loading_options) {
     utils::imgui::InfoMarker(
         "(?)",
         "Size of the preview image's longer side in pixels.\n - decrease to "
-        "get faster loading times.\n - increase to get more precision for "
-        "panorama detection.");
+        "get faster loading times.\n - increase to get nicer preview images\n "
+        "- increase to get more precision for panorama detection.");
     ImGui::EndMenu();
   }
 }

--- a/xpano/gui/panels/sidebar.cc
+++ b/xpano/gui/panels/sidebar.cc
@@ -59,7 +59,8 @@ Action DrawFileMenu() {
 
 Action DrawOptionsMenu(algorithm::CompressionOptions* compression_options,
                        algorithm::LoadingOptions* loading_options,
-                       algorithm::MatchingOptions* matching_options) {
+                       algorithm::MatchingOptions* matching_options,
+                       algorithm::ProjectionOptions* projection_options) {
   Action action{};
   if (ImGui::BeginMenu("Options")) {
     if (ImGui::BeginMenu("Export compression")) {
@@ -112,6 +113,32 @@ Action DrawOptionsMenu(algorithm::CompressionOptions* compression_options,
           "(?)",
           "Number of keypoints that need to match in order to include the two "
           "images in a panorama.");
+      ImGui::EndMenu();
+    }
+    if (ImGui::BeginMenu("Panorama stitching")) {
+      ImGui::Text("Advanced projection options.");
+      ImGui::Spacing();
+      if (ImGui::BeginCombo("Projection type",
+                            Label(projection_options->projection_type))) {
+        for (const auto projection_type : algorithm::kProjectionTypes) {
+          if (ImGui::Selectable(
+                  Label(projection_type),
+                  projection_type == projection_options->projection_type)) {
+            projection_options->projection_type = projection_type;
+            action |= {ActionType::kRecomputePano};
+          }
+        }
+        ImGui::EndCombo();
+      }
+      if (algorithm::HasAdvancedParameters(
+              projection_options->projection_type)) {
+        if (ImGui::InputFloat("a", &projection_options->a_param, 0.5f, 0.5f)) {
+          action |= {ActionType::kRecomputePano};
+        }
+        if (ImGui::InputFloat("b", &projection_options->b_param, 0.5f, 0.5f)) {
+          action |= {ActionType::kRecomputePano};
+        }
+      }
       ImGui::EndMenu();
     }
     ImGui::EndMenu();
@@ -243,12 +270,13 @@ Action DrawPanosMenu(const std::vector<algorithm::Pano>& panos,
 
 Action DrawMenu(algorithm::CompressionOptions* compression_options,
                 algorithm::LoadingOptions* loading_options,
-                algorithm::MatchingOptions* matching_options) {
+                algorithm::MatchingOptions* matching_options,
+                algorithm::ProjectionOptions* projection_options) {
   Action action{};
   if (ImGui::BeginMenuBar()) {
     action |= DrawFileMenu();
-    action |=
-        DrawOptionsMenu(compression_options, loading_options, matching_options);
+    action |= DrawOptionsMenu(compression_options, loading_options,
+                              matching_options, projection_options);
     action |= DrawHelpMenu();
     ImGui::EndMenuBar();
   }

--- a/xpano/gui/panels/sidebar.cc
+++ b/xpano/gui/panels/sidebar.cc
@@ -122,9 +122,9 @@ Action DrawProjectionOptionsMenu(
     algorithm::ProjectionOptions* projection_options) {
   Action action{};
   if (ImGui::BeginMenu("Panorama stitching")) {
-    ImGui::Text("Advanced projection options.");
+    ImGui::Text("Projection type:");
     ImGui::Spacing();
-    if (ImGui::BeginCombo("Projection type",
+    if (ImGui::BeginCombo("##projection_type",
                           Label(projection_options->projection_type))) {
       for (const auto projection_type : algorithm::kProjectionTypes) {
         if (ImGui::Selectable(
@@ -137,6 +137,8 @@ Action DrawProjectionOptionsMenu(
       ImGui::EndCombo();
     }
     if (algorithm::HasAdvancedParameters(projection_options->projection_type)) {
+      ImGui::Text("Advanced projection parameters:");
+      ImGui::Spacing();
       if (ImGui::InputFloat("a", &projection_options->a_param, 0.5f, 0.5f)) {
         action |= {ActionType::kRecomputePano};
       }

--- a/xpano/gui/panels/sidebar.h
+++ b/xpano/gui/panels/sidebar.h
@@ -25,7 +25,8 @@ Action DrawPanosMenu(const std::vector<algorithm::Pano>& panos,
 
 Action DrawMenu(algorithm::CompressionOptions* compression_options,
                 algorithm::LoadingOptions* loading_options,
-                algorithm::MatchingOptions* matching_options);
+                algorithm::MatchingOptions* matching_options,
+                algorithm::ProjectionOptions* projection_options);
 
 void DrawWelcomeText();
 

--- a/xpano/gui/pano_gui.h
+++ b/xpano/gui/pano_gui.h
@@ -55,6 +55,7 @@ class PanoGui {
   algorithm::CompressionOptions compression_options_;
   algorithm::LoadingOptions loading_options_;
   algorithm::MatchingOptions matching_options_;
+  algorithm::ProjectionOptions projection_options_;
   std::optional<algorithm::StitcherData> stitcher_data_;
 
   // Gui panels


### PR DESCRIPTION
Progress in #18

Added option to select from multiple panorama projection types from OpenCV: https://docs.opencv.org/4.6.0/dc/de7/detail_2warpers_8hpp.html

- Perspective
- Cylindrical
- Spherical
- Fisheye
- Stereographic
- CompressedRectilinear
- CompressedRectilinearPortrait
- Panini
- PaniniPortrait
- Mercator
- TransverseMercator