### PR TITLE
SIFT by default in the stitch algorithm

### DIFF
--- a/xpano/algorithm/algorithm.h
+++ b/xpano/algorithm/algorithm.h
@@ -61,6 +61,12 @@ const char* Label(ProjectionType projection_type);
 
 bool HasAdvancedParameters(ProjectionType projection_type);
 
+enum class FeatureType { kSift, kOrb };
+
+const auto kFeatureTypes = std::array{FeatureType::kSift, FeatureType::kOrb};
+
+const char* Label(FeatureType feature_type);
+
 struct ProjectionOptions {
   ProjectionType type = ProjectionType::kSpherical;
   float a_param = kDefaultPaniniA;
@@ -69,7 +75,7 @@ struct ProjectionOptions {
 
 struct StitchOptions {
   ProjectionOptions projection;
-  bool return_pano_mask = false;
+  FeatureType feature = FeatureType::kSift;
 };
 
 struct StitchResult {
@@ -78,7 +84,8 @@ struct StitchResult {
   cv::Mat mask;
 };
 
-StitchResult Stitch(const std::vector<cv::Mat>& images, StitchOptions options);
+StitchResult Stitch(const std::vector<cv::Mat>& images, StitchOptions options,
+                    bool return_pano_mask);
 
 std::string ToString(cv::Stitcher::Status& status);
 

--- a/xpano/gui/panels/sidebar.h
+++ b/xpano/gui/panels/sidebar.h
@@ -28,7 +28,7 @@ Action DrawMenu(pipeline::CompressionOptions* compression_options,
                 pipeline::LoadingOptions* loading_options,
                 pipeline::InpaintingOptions* inpaint_options,
                 pipeline::MatchingOptions* matching_options,
-                pipeline::ProjectionOptions* projection_options,
+                pipeline::StitchAlgorithmOptions* stitch_options,
                 bool debug_enabled);
 
 void DrawWelcomeTextPart1();

--- a/xpano/gui/pano_gui.cc
+++ b/xpano/gui/pano_gui.cc
@@ -274,7 +274,7 @@ Action PanoGui::DrawSidebar() {
                ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoScrollbar);
   action |=
       DrawMenu(&compression_options_, &loading_options_, &inpaint_options_,
-               &matching_options_, &projection_options_, IsDebugEnabled());
+               &matching_options_, &stitch_options_, IsDebugEnabled());
 
   DrawWelcomeTextPart1();
   action |= DrawImportActionButtons();
@@ -357,7 +357,7 @@ Action PanoGui::PerformAction(Action action) {
                                   .full_res = true,
                                   .export_path = *export_path,
                                   .compression = compression_options_,
-                                  .projection = projection_options_});
+                                  .stitch_algorithm = stitch_options_});
           }
         }
       }
@@ -406,7 +406,7 @@ Action PanoGui::PerformAction(Action action) {
           *stitcher_data_,
           {.pano_id = selection_.target_id,
            .full_res = action.type == ActionType::kShowFullResPano,
-           .projection = projection_options_});
+           .stitch_algorithm = stitch_options_});
       const auto& pano = stitcher_data_->panos[selection_.target_id];
       thumbnail_pane_.SetScrollX(pano.ids);
       thumbnail_pane_.Highlight(pano.ids);
@@ -418,7 +418,7 @@ Action PanoGui::PerformAction(Action action) {
     case ActionType::kRecomputePano: {
       if (selection_.type == SelectionType::kPano) {
         spdlog::info("Recomputing pano {}: {}", selection_.target_id,
-                     Label(projection_options_.type));
+                     Label(stitch_options_.projection.type));
         return {.type = ActionType::kShowPano,
                 .target_id = selection_.target_id,
                 .delayed = true};

--- a/xpano/gui/pano_gui.h
+++ b/xpano/gui/pano_gui.h
@@ -60,7 +60,7 @@ class PanoGui {
   pipeline::LoadingOptions loading_options_;
   pipeline::InpaintingOptions inpaint_options_;
   pipeline::MatchingOptions matching_options_;
-  pipeline::ProjectionOptions projection_options_;
+  pipeline::StitchAlgorithmOptions stitch_options_;
   std::optional<pipeline::StitcherData> stitcher_data_;
 
   // Gui panels

--- a/xpano/pipeline/stitcher_pipeline.cc
+++ b/xpano/pipeline/stitcher_pipeline.cc
@@ -111,9 +111,9 @@ StitchingResult StitcherPipeline::RunStitchingPipeline(
   }
 
   progress_.SetTaskType(ProgressType::kStitchingPano);
-  auto [status, result, mask] = algorithm::Stitch(
-      imgs,
-      {.projection = options.projection, .return_pano_mask = options.full_res});
+  auto [status, result, mask] =
+      algorithm::Stitch(imgs, options.stitch_algorithm,
+                        /*return_pano_mask=*/options.full_res);
   progress_.NotifyTaskDone();
 
   if (status != cv::Stitcher::OK) {

--- a/xpano/pipeline/stitcher_pipeline.h
+++ b/xpano/pipeline/stitcher_pipeline.h
@@ -18,7 +18,7 @@
 namespace xpano::pipeline {
 
 using InpaintingOptions = algorithm::InpaintingOptions;
-using ProjectionOptions = algorithm::ProjectionOptions;
+using StitchAlgorithmOptions = algorithm::StitchOptions;
 
 struct CompressionOptions {
   int jpeg_quality = kDefaultJpegQuality;
@@ -41,7 +41,7 @@ struct StitchingOptions {
   bool full_res = false;
   std::optional<std::string> export_path;
   CompressionOptions compression;
-  ProjectionOptions projection;
+  StitchAlgorithmOptions stitch_algorithm;
 };
 
 struct ExportOptions {


### PR DESCRIPTION
1) Make [SIFT](https://docs.opencv.org/4.x/d7/d60/classcv_1_1SIFT.html) the default algorithm in the panorama stitching
    - This is already the case for panorama detection, so this change makes the app behave consistently

2) In debug mode, the algorithm can be switched to default [ORB](https://docs.opencv.org/3.4/db/d95/classcv_1_1ORB.html) behavior

3) Refactor of StitchOptions, so that more stitching options can be controlled through the GUI, this advances #18 

Fixes #64 