### PR TITLE
selectable match confidence for detection/stitching

### DIFF
--- a/xpano/algorithm/algorithm.h
+++ b/xpano/algorithm/algorithm.h
@@ -25,7 +25,8 @@ struct Match {
   std::vector<cv::DMatch> matches;
 };
 
-std::vector<cv::DMatch> MatchImages(const Image& img1, const Image& img2);
+std::vector<cv::DMatch> MatchImages(const Image& img1, const Image& img2,
+                                    float match_conf);
 
 std::vector<Pano> FindPanos(const std::vector<Match>& matches,
                             int match_threshold);
@@ -76,6 +77,7 @@ struct ProjectionOptions {
 struct StitchOptions {
   ProjectionOptions projection;
   FeatureType feature = FeatureType::kSift;
+  float match_conf = kDefaultMatchConf;
 };
 
 struct StitchResult {

--- a/xpano/constants.h
+++ b/xpano/constants.h
@@ -65,6 +65,9 @@ constexpr int kStepPreviewLongerSide = 256;
 
 constexpr float kDefaultPaniniA = 2.0f;
 constexpr float kDefaultPaniniB = 1.0f;
+constexpr float kDefaultMatchConf = 0.25f;
+constexpr float kMinMatchConf = 0.1f;
+constexpr float kMaxMatchConf = 0.4f;
 
 const std::string kConfigFilename = "config.txt";
 

--- a/xpano/pipeline/stitcher_pipeline.cc
+++ b/xpano/pipeline/stitcher_pipeline.cc
@@ -238,8 +238,10 @@ StitcherData StitcherPipeline::RunMatchingPipeline(
   for (int j = 0; j < images.size(); j++) {
     for (int i = std::max(0, j - num_neighbors); i < j; i++) {
       matches_future.push_back(
-          pool_.submit([this, i, j, left = images[i], right = images[j]]() {
-            auto match = algorithm::Match{i, j, MatchImages(left, right)};
+          pool_.submit([this, i, j, left = images[i], right = images[j],
+                        match_conf = options.match_conf]() {
+            auto match =
+                algorithm::Match{i, j, MatchImages(left, right, match_conf)};
             progress_.NotifyTaskDone();
             return match;
           }));

--- a/xpano/pipeline/stitcher_pipeline.h
+++ b/xpano/pipeline/stitcher_pipeline.h
@@ -30,6 +30,7 @@ struct CompressionOptions {
 struct MatchingOptions {
   int neighborhood_search_size = kDefaultNeighborhoodSearchSize;
   int match_threshold = kDefaultMatchThreshold;
+  float match_conf = kDefaultMatchConf;
 };
 
 struct LoadingOptions {


### PR DESCRIPTION
relation to distance ratio from Lowe's paper: 
match confidence = 1 - (distance ratio)