### PR TITLE
Feature chroma subsampling

### DIFF
--- a/xpano/gui/panels/sidebar.cc
+++ b/xpano/gui/panels/sidebar.cc
@@ -67,12 +67,22 @@ Action DrawFileMenu() {
 void DrawCompressionOptionsMenu(
     pipeline::CompressionOptions* compression_options) {
   if (ImGui::BeginMenu("Export compression")) {
-    ImGui::SliderInt("JPEG quality", &compression_options->jpeg_quality, 0,
+    ImGui::Text("JPEG");
+    ImGui::SliderInt("Quality", &compression_options->jpeg_quality, 0,
                      kMaxJpegQuality);
-    ImGui::Checkbox("JPEG progressive", &compression_options->jpeg_progressive);
-    ImGui::Checkbox("JPEG optimize", &compression_options->jpeg_optimize);
-    ImGui::SliderInt("PNG compression", &compression_options->png_compression,
-                     0, kMaxPngCompression);
+    ImGui::Checkbox("Progressive", &compression_options->jpeg_progressive);
+    ImGui::Checkbox("Optimize", &compression_options->jpeg_optimize);
+    ImGui::Text("Chroma subsampling:");
+    ImGui::SameLine();
+    utils::imgui::RadioBox(&compression_options->jpeg_subsampling,
+                           pipeline::kSubsamplingModes);
+    utils::imgui::InfoMarker("(?)",
+                             "Corresponding to the 4:4:4, 4:2:2 and 4:2:0 "
+                             "chroma subsampling modes.");
+    ImGui::Separator();
+    ImGui::Text("PNG");
+    ImGui::SliderInt("Compression", &compression_options->png_compression, 0,
+                     kMaxPngCompression);
     ImGui::EndMenu();
   }
 }

--- a/xpano/gui/panels/sidebar.cc
+++ b/xpano/gui/panels/sidebar.cc
@@ -155,7 +155,7 @@ void DrawMatchingOptionsMenu(pipeline::MatchingOptions* matching_options,
         "Number of keypoints that need to match in order to include the two "
         "images in a panorama.");
     if (debug_enabled) {
-      ImGui::Text("[debug options]");
+      ImGui::SeparatorText("Debug");
       DrawMatchConf(&matching_options->match_conf);
     }
     ImGui::EndMenu();
@@ -229,7 +229,7 @@ Action DrawStitchOptionsMenu(pipeline::StitchAlgorithmOptions* stitch_options,
     action |= DrawWaveCorrectionOptions(stitch_options);
 
     if (debug_enabled) {
-      ImGui::Text("[debug options]");
+      ImGui::SeparatorText("Debug");
       action |= DrawFeatureMatchingOptions(stitch_options);
 
       if (DrawMatchConf(&stitch_options->match_conf)) {
@@ -243,7 +243,7 @@ Action DrawStitchOptionsMenu(pipeline::StitchAlgorithmOptions* stitch_options,
 
 void DrawAutofillOptionsMenu(pipeline::InpaintingOptions* inpaint_options) {
   if (ImGui::BeginMenu("Auto fill")) {
-    ImGui::Text("[debug options]");
+    ImGui::SeparatorText("Debug");
     ImGui::Text("Algorithm:");
     ImGui::Spacing();
     utils::imgui::ComboBox(&inpaint_options->method,

--- a/xpano/gui/pano_gui.cc
+++ b/xpano/gui/pano_gui.cc
@@ -300,6 +300,7 @@ Action PanoGui::DrawSidebar() {
     action |=
         DrawPanosMenu(stitcher_data_->panos, thumbnail_pane_, highlight_id);
     if (IsDebugEnabled()) {
+      ImGui::SeparatorText("Debug");
       auto highlight_id =
           selection_.type == SelectionType::kMatch ? selection_.target_id : -1;
       action |= DrawMatchesMenu(stitcher_data_->matches, thumbnail_pane_,

--- a/xpano/pipeline/stitcher_pipeline.cc
+++ b/xpano/pipeline/stitcher_pipeline.cc
@@ -22,15 +22,43 @@
 namespace xpano::pipeline {
 namespace {
 
+cv::ImwriteJPEGSamplingFactorParams ToOpenCVEnum(
+    const ChromaSubsampling &subsampling) {
+  switch (subsampling) {
+    case ChromaSubsampling::k444:
+      return cv::IMWRITE_JPEG_SAMPLING_FACTOR_444;
+    case ChromaSubsampling::k422:
+      return cv::IMWRITE_JPEG_SAMPLING_FACTOR_422;
+    case ChromaSubsampling::k420:
+      return cv::IMWRITE_JPEG_SAMPLING_FACTOR_420;
+  }
+}
+
 std::vector<int> CompressionParameters(const CompressionOptions &options) {
-  return {
-      cv::IMWRITE_JPEG_QUALITY,     options.jpeg_quality,
-      cv::IMWRITE_JPEG_PROGRESSIVE, static_cast<int>(options.jpeg_progressive),
-      cv::IMWRITE_JPEG_OPTIMIZE,    static_cast<int>(options.jpeg_optimize),
-      cv::IMWRITE_PNG_COMPRESSION,  options.png_compression};
+  return {cv::IMWRITE_JPEG_QUALITY,
+          options.jpeg_quality,
+          cv::IMWRITE_JPEG_PROGRESSIVE,
+          static_cast<int>(options.jpeg_progressive),
+          cv::IMWRITE_JPEG_OPTIMIZE,
+          static_cast<int>(options.jpeg_optimize),
+          cv::IMWRITE_JPEG_SAMPLING_FACTOR,
+          ToOpenCVEnum(options.jpeg_subsampling),
+          cv::IMWRITE_PNG_COMPRESSION,
+          options.png_compression};
 }
 
 }  // namespace
+
+const char *Label(ChromaSubsampling subsampling) {
+  switch (subsampling) {
+    case ChromaSubsampling::k444:
+      return "Off";
+    case ChromaSubsampling::k422:
+      return "Half";
+    case ChromaSubsampling::k420:
+      return "Quarter";
+  }
+}
 
 void ProgressMonitor::Reset(ProgressType type, int num_tasks) {
   type_ = type;

--- a/xpano/pipeline/stitcher_pipeline.cc
+++ b/xpano/pipeline/stitcher_pipeline.cc
@@ -31,6 +31,8 @@ cv::ImwriteJPEGSamplingFactorParams ToOpenCVEnum(
       return cv::IMWRITE_JPEG_SAMPLING_FACTOR_422;
     case ChromaSubsampling::k420:
       return cv::IMWRITE_JPEG_SAMPLING_FACTOR_420;
+    default:
+      return cv::IMWRITE_JPEG_SAMPLING_FACTOR_422;
   }
 }
 
@@ -57,6 +59,8 @@ const char *Label(ChromaSubsampling subsampling) {
       return "Half";
     case ChromaSubsampling::k420:
       return "Quarter";
+    default:
+      return "Unknown";
   }
 }
 

--- a/xpano/pipeline/stitcher_pipeline.h
+++ b/xpano/pipeline/stitcher_pipeline.h
@@ -20,10 +20,22 @@ namespace xpano::pipeline {
 using InpaintingOptions = algorithm::InpaintingOptions;
 using StitchAlgorithmOptions = algorithm::StitchOptions;
 
+enum class ChromaSubsampling {
+  k444,
+  k422,
+  k420,
+};
+
+const auto kSubsamplingModes = std::array{
+    ChromaSubsampling::k444, ChromaSubsampling::k422, ChromaSubsampling::k420};
+
+const char *Label(ChromaSubsampling subsampling);
+
 struct CompressionOptions {
   int jpeg_quality = kDefaultJpegQuality;
   bool jpeg_progressive = false;
   bool jpeg_optimize = false;
+  ChromaSubsampling jpeg_subsampling = ChromaSubsampling::k422;
   int png_compression = kDefaultPngCompression;
 };
 

--- a/xpano/utils/imgui_.h
+++ b/xpano/utils/imgui_.h
@@ -61,4 +61,15 @@ bool ComboBox(TOptionType* current_option,
   return selected;
 }
 
+template <typename TOptionType, std::size_t N>
+void RadioBox(TOptionType* current_option,
+              const std::array<TOptionType, N>& options) {
+  for (const auto& option : options) {
+    if (ImGui::RadioButton(Label(option), option == *current_option)) {
+      *current_option = option;
+    }
+    ImGui::SameLine();
+  }
+}
+
 }  // namespace xpano::utils::imgui


### PR DESCRIPTION
Selectable chroma subsampling modes for jpeg exports: 4:4:4, 4:2:2, 4:2:0.

The default previously was 4:2:0: https://docs.opencv.org/4.x/d8/d6a/group__imgcodecs__flags.html#ga4b97ca569a53587801257896d79656e1

Switching the default to 4:2:2