### PR TITLE
Feature extra data in Action

### DIFF
--- a/xpano/gui/action.h
+++ b/xpano/gui/action.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <iterator>
+#include <variant>
 #include <vector>
 
 namespace xpano::gui {
@@ -19,7 +20,6 @@ enum class ActionType {
   kShowImage,
   kShowMatch,
   kShowPano,
-  kShowFullResPano,
   kModifyPano,
   kRecomputePano,
   kQuit,
@@ -28,11 +28,25 @@ enum class ActionType {
   kResetOptions
 };
 
+struct ShowPanoExtra {
+  bool full_res = false;
+  bool scroll_thumbnails = false;
+};
+
 struct Action {
   ActionType type = ActionType::kNone;
   int target_id;
   bool delayed = false;
+  std::variant<ShowPanoExtra> extra;
 };
+
+template <typename TExtraType>
+TExtraType ValueOrDefault(const Action& action) {
+  if (const auto* extra = std::get_if<TExtraType>(&action.extra); extra) {
+    return *extra;
+  }
+  return {};
+}
 
 struct MultiAction {
   std::vector<Action> items;
@@ -70,6 +84,7 @@ inline Action& operator|=(Action& lhs, const Action& rhs) {
     lhs.type = rhs.type;
     lhs.target_id = rhs.target_id;
     lhs.delayed = rhs.delayed;
+    lhs.extra = rhs.extra;
   }
   return lhs;
 }

--- a/xpano/gui/panels/sidebar.cc
+++ b/xpano/gui/panels/sidebar.cc
@@ -74,9 +74,9 @@ void DrawCompressionOptionsMenu(
                      kMaxJpegQuality);
     ImGui::Checkbox("Progressive", &compression_options->jpeg_progressive);
     ImGui::Checkbox("Optimize", &compression_options->jpeg_optimize);
-    ImGui::Text("Chroma subsampling:");
-    ImGui::SameLine();
     if constexpr (utils::opencv::HasJpegSubsamplingSupport()) {
+      ImGui::Text("Chroma subsampling:");
+      ImGui::SameLine();
       utils::imgui::RadioBox(&compression_options->jpeg_subsampling,
                              pipeline::kSubsamplingModes);
       utils::imgui::InfoMarker("(?)",

--- a/xpano/gui/panels/sidebar.cc
+++ b/xpano/gui/panels/sidebar.cc
@@ -401,7 +401,9 @@ Action DrawPanosMenu(const std::vector<algorithm::Pano>& panos,
       ImGui::TableNextColumn();
       ImGui::PushID(i);
       if (ImGui::SmallButton("Show")) {
-        action = {ActionType::kShowPano, i};
+        action = {.type = ActionType::kShowPano,
+                  .target_id = i,
+                  .extra = ShowPanoExtra{.scroll_thumbnails = true}};
       }
       ImGui::PopID();
 
@@ -475,8 +477,9 @@ Action DrawActionButtons(ImageType image_type, int target_id,
       image_type == ImageType::kPanoPreview,
       [&] {
         if (ImGui::Button("Full-res")) {
-          action |=
-              {.type = ActionType::kShowFullResPano, .target_id = target_id};
+          action |= {.type = ActionType::kShowPano,
+                     .target_id = target_id,
+                     .extra = ShowPanoExtra{.full_res = true}};
         }
       },
       image_type == ImageType::kPanoFullRes ? "Already computed"

--- a/xpano/gui/pano_gui.cc
+++ b/xpano/gui/pano_gui.cc
@@ -429,20 +429,20 @@ Action PanoGui::PerformAction(Action action) {
       thumbnail_pane_.Highlight(match.id1, match.id2);
       break;
     }
-    case ActionType::kShowFullResPano:
-      [[fallthrough]];
     case ActionType::kShowPano: {
       selection_ = {SelectionType::kPano, action.target_id};
       spdlog::info("Calculating pano preview {}", selection_.target_id);
       status_message_ = {};
+      auto extra = ValueOrDefault<ShowPanoExtra>(action);
       pano_future_ = stitcher_pipeline_.RunStitching(
-          *stitcher_data_,
-          {.pano_id = selection_.target_id,
-           .full_res = action.type == ActionType::kShowFullResPano,
-           .stitch_algorithm = options_.stitch});
+          *stitcher_data_, {.pano_id = selection_.target_id,
+                            .full_res = extra.full_res,
+                            .stitch_algorithm = options_.stitch});
       const auto& pano = stitcher_data_->panos[selection_.target_id];
-      thumbnail_pane_.SetScrollX(pano.ids);
       thumbnail_pane_.Highlight(pano.ids);
+      if (extra.scroll_thumbnails) {
+        thumbnail_pane_.SetScrollX(pano.ids);
+      }
       break;
     }
     case ActionType::kModifyPano: {

--- a/xpano/gui/pano_gui.cc
+++ b/xpano/gui/pano_gui.cc
@@ -504,7 +504,10 @@ MultiAction PanoGui::ResolveFutures() {
       actions |= {.type = ActionType::kWarnInputConversion};
     }
     if (stitcher_data_ && !stitcher_data_->panos.empty()) {
-      actions |= {.type = ActionType::kShowPano, .target_id = 0};
+      actions |= {.type = ActionType::kShowPano,
+                  .target_id = 0,
+                  .delayed = true,
+                  .extra = ShowPanoExtra{.scroll_thumbnails = true}};
     }
   }
 


### PR DESCRIPTION
Add an `std::variant extra` field to `Action` objects for passing extra data.
- only scroll to a pano if selecting it from the menu
- do not autoscroll if recomputing due to options change / adding or removing images, the scrolling was confusing

Small fixes
 - correctly autoscroll to the first found pano
 - fix for disabled chroma subsampling options