### PR TITLE
Make exiv2 dependency optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,17 @@ endif()
 find_package(SDL2 REQUIRED)
 find_package(OpenCV REQUIRED COMPONENTS calib3d core features2d flann imgcodecs imgproc photo stitching)
 find_package(spdlog REQUIRED)
-find_package(exiv2 REQUIRED)
+find_package(exiv2 0.28.0 QUIET)
+
+if (exiv2_FOUND)
+  message(STATUS "Building with exiv2 version ${exiv2_VERSION}")
+else()
+  message(STATUS "Building without exiv2 support")
+  if (exiv2_CONSIDERED_VERSIONS)
+    message(STATUS "  Required version: 0.28.0")
+    message(STATUS "  Found exiv2 versions: ${exiv2_CONSIDERED_VERSIONS}")
+  endif()
+endif()
 
 add_executable(Xpano WIN32
   ${XPANO_SOURCES}
@@ -112,8 +122,12 @@ target_link_libraries(Xpano
   SDL2::SDL2
   SDL2::SDL2main
   spdlog::spdlog
-  exiv2lib
 )
+
+if(exiv2_FOUND)
+  target_compile_definitions(Xpano PRIVATE XPANO_WITH_EXIV2)
+  target_link_libraries(Xpano exiv2lib)
+endif()
 
 copy_runtime_dlls(Xpano)
 copy_directory(Xpano 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,10 +223,12 @@ install(FILES
   RENAME "opencv-license.txt"
   OPTIONAL
 )
-install(FILES
-  "misc/build/exiv2-notice.txt"
-  DESTINATION "${CMAKE_INSTALL_DATADIR}/licenses"
-)
+if (exiv2_FOUND)
+  install(FILES
+    "misc/build/exiv2-notice.txt"
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/licenses"
+  )
+endif()
 if(DEFINED XPANO_EXTRA_LICENSES)
   install(DIRECTORY
     "${XPANO_EXTRA_LICENSES}"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,8 +37,12 @@ target_link_libraries(StitcherTest
   Catch2::Catch2WithMain
   ${OPENCV_TARGETS}
   spdlog::spdlog
-  exiv2lib
 )
+
+if(exiv2_FOUND)
+  target_compile_definitions(StitcherTest PRIVATE XPANO_WITH_EXIV2)
+  target_link_libraries(StitcherTest exiv2lib)
+endif()
 
 target_include_directories(StitcherTest PRIVATE 
   ".."

--- a/tests/stitcher_pipeline_test.cc
+++ b/tests/stitcher_pipeline_test.cc
@@ -11,7 +11,9 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <catch2/matchers/catch_matchers_vector.hpp>
+#ifdef XPANO_WITH_EXIV2
 #include <exiv2/exiv2.hpp>
+#endif
 #include <opencv2/core.hpp>
 #include <opencv2/imgcodecs.hpp>
 #include <opencv2/imgproc.hpp>
@@ -292,6 +294,7 @@ TEST_CASE("ExportWithMetadata") {
   CHECK_THAT(image.rows, WithinRel(977, eps));
   CHECK_THAT(image.cols, WithinRel(1334, eps));
 
+#ifdef XPANO_WITH_EXIV2
   auto read_img = Exiv2::ImageFactory::open(tmp_path.string());
   read_img->readMetadata();
   auto exif = read_img->exifData();
@@ -311,13 +314,15 @@ TEST_CASE("ExportWithMetadata") {
   CHECK_THAT(thumb.mimeType(), Equals(""));
   CHECK_THAT(thumb.extension(), Equals(""));
   CHECK(thumb.copy().empty());
-
+#endif
   std::filesystem::remove(tmp_path);
 }
 
+#ifdef XPANO_WITH_EXIV2
 bool TagExists(const Exiv2::ExifData& exif, const std::string& tag) {
   return exif.findKey(Exiv2::ExifKey(tag)) != exif.end();
 }
+#endif
 
 TEST_CASE("ExportWithoutMetadata") {
   const std::filesystem::path tmp_path =
@@ -333,8 +338,9 @@ TEST_CASE("ExportWithoutMetadata") {
       .get();
 
   const float eps = 0.01;
-
   REQUIRE(std::filesystem::exists(tmp_path));
+
+#ifdef XPANO_WITH_EXIV2
   auto read_img = Exiv2::ImageFactory::open(tmp_path.string());
   read_img->readMetadata();
   auto exif = read_img->exifData();
@@ -350,6 +356,7 @@ TEST_CASE("ExportWithoutMetadata") {
   CHECK_THAT(thumb.mimeType(), Equals(""));
   CHECK_THAT(thumb.extension(), Equals(""));
   CHECK(thumb.copy().empty());
+#endif
 
   std::filesystem::remove(tmp_path);
 }

--- a/xpano/gui/panels/sidebar.cc
+++ b/xpano/gui/panels/sidebar.cc
@@ -22,6 +22,7 @@
 #include "xpano/gui/shortcut.h"
 #include "xpano/pipeline/options.h"
 #include "xpano/pipeline/stitcher_pipeline.h"
+#include "xpano/utils/exiv2.h"
 #include "xpano/utils/imgui_.h"
 #include "xpano/utils/opencv.h"
 
@@ -74,13 +75,20 @@ void DrawExportOptionsMenu(pipeline::MetadataOptions* metadata_options,
                            pipeline::CompressionOptions* compression_options) {
   if (ImGui::BeginMenu("Image export")) {
     ImGui::Text("Exif metadata");
-    ImGui::Checkbox("Copy from first image",
-                    &metadata_options->copy_from_first_image);
-    ImGui::SameLine();
-    utils::imgui::InfoMarker(
-        "(?)",
-        "Copy the Exif metadata from the first image of the exported "
-        "panorama.\nSupported file extensions: jpg, jpeg, tif, tiff.");
+    utils::imgui::EnableIf(
+        utils::exiv2::Enabled(),
+        [&] {
+          ImGui::Checkbox("Copy from first image",
+                          &metadata_options->copy_from_first_image);
+          ImGui::SameLine();
+          utils::imgui::InfoMarker(
+              "(?)",
+              "Copy the Exif metadata from the first image of the exported "
+              "panorama.\nSupported file extensions: jpg, jpeg, tif, tiff.");
+        },
+        "This version was not built with exif support.\nAvailable in: Flatpak, "
+        "Windows, built from source.");
+
     ImGui::Spacing();
     ImGui::Separator();
     ImGui::Text("JPEG");

--- a/xpano/pipeline/options.h
+++ b/xpano/pipeline/options.h
@@ -7,6 +7,7 @@
 
 #include "xpano/algorithm/options.h"
 #include "xpano/constants.h"
+#include "xpano/utils/exiv2.h"
 
 namespace xpano::pipeline {
 
@@ -37,7 +38,7 @@ const auto kMatchingTypes = std::array{
 /*****************************************************************************/
 
 struct MetadataOptions {
-  bool copy_from_first_image = true;
+  bool copy_from_first_image = utils::exiv2::Enabled();
 };
 
 struct CompressionOptions {

--- a/xpano/pipeline/stitcher_pipeline.cc
+++ b/xpano/pipeline/stitcher_pipeline.cc
@@ -205,7 +205,7 @@ ExportResult StitcherPipeline::RunExportPipeline(cv::Mat pano,
     export_path = options.export_path;
   }
   progress_.NotifyTaskDone();
-  if (export_path) {
+  if (export_path && utils::exiv2::Enabled()) {
     auto pano_size = utils::ToIntVec(pano.size);
     utils::exiv2::CreateExif(options.metadata_path, *export_path, pano_size);
   }

--- a/xpano/utils/exiv2.cc
+++ b/xpano/utils/exiv2.cc
@@ -3,7 +3,9 @@
 
 #include "xpano/utils/exiv2.h"
 
+#ifdef XPANO_WITH_EXIV2
 #include <exiv2/exiv2.hpp>
+#endif
 #include <spdlog/fmt/fmt.h>
 #include <spdlog/spdlog.h>
 
@@ -15,7 +17,7 @@
 namespace xpano::utils::exiv2 {
 
 namespace {
-
+#ifdef XPANO_WITH_EXIV2
 template <typename TValueType>
 void UpdateTagIfExisting(Exiv2::ExifData& exif_data, const std::string& key,
                          TValueType value) {
@@ -46,11 +48,12 @@ void EraseThumbnail(Exiv2::ExifData& exif_data) {
   auto thumb = Exiv2::ExifThumb(exif_data);
   thumb.erase();
 }
-
+#endif
 }  // namespace
 
 void CreateExif(const std::optional<std::filesystem::path>& from_path,
                 const std::filesystem::path& to_path, const Vec2i& image_size) {
+#ifdef XPANO_WITH_EXIV2
   if (from_path && !path::IsMetadataExtensionSupported(*from_path)) {
     spdlog::info("Reading metadata is not supported for {}",
                  from_path->string());
@@ -83,6 +86,9 @@ void CreateExif(const std::optional<std::filesystem::path>& from_path,
   } catch (const Exiv2::Error&) {
     spdlog::warn("Could not write Exif data to {}", to_path.string());
   }
+#else
+  spdlog::error("Exiv2 support is not enabled");
+#endif
 }
 
 }  // namespace xpano::utils::exiv2

--- a/xpano/utils/exiv2.h
+++ b/xpano/utils/exiv2.h
@@ -10,6 +10,14 @@
 
 namespace xpano::utils::exiv2 {
 
+constexpr bool Enabled() {
+#ifdef XPANO_WITH_EXIV2
+  return true;
+#else
+  return false;
+#endif
+}
+
 void CreateExif(const std::optional<std::filesystem::path>& from_path,
                 const std::filesystem::path& to_path, const Vec2i& image_size);
 


### PR DESCRIPTION
We cannot build with exiv2 on launchpad for now as the required 0.28.0 version is not yet available in the packages:
- https://packages.ubuntu.com/search?keywords=libexiv2-dev

Added info in the app about supported versions:

![image](https://github.com/krupkat/xpano/assets/6817216/6264e2dc-697f-4bad-b61d-4fadf7a37c1c)

