### PR TITLE
Feature multiblend

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,7 +2,7 @@ BasedOnStyle: Google
 
 SortIncludes: CaseInsensitive
 IncludeCategories:
-  - Regex:           '<(absl|BS_|imgui|nfd|opencv2|SDL|catch|spdlog|alpaca|tl|exiv2).*>'
+  - Regex:           '<(absl|BS_|imgui|nfd|opencv2|SDL|catch|spdlog|alpaca|tl|exiv2|mb).*>'
     Priority:        2
   - Regex:           '<[[:alnum:]._]+>'
     Priority:        1

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -68,3 +68,5 @@ CheckOptions:
     value: L;LL
   - key:   readability-magic-numbers.IgnoreAllFloatingPointValues
     value: 1
+  - key:   readability-identifier-length.IgnoredLoopCounterNames
+    value: ^[ijkxy_]$

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -236,7 +236,8 @@ jobs:
     runs-on: ubuntu-20.04
 
     # Build OpenCV from source, as the one included in 20.04 repos doesn't have SIFT features
-    # Build SDL from source as it the one included in 20.04 doesn't export modern cmake targets
+    # Build SDL from source as the one included in 20.04 doesn't export modern cmake targets
+    # Build spdlog from source as the one included in 20.04 doesn't include fmt::format_string
     # Use gcc 10 instead of default gcc 9, because of required concepts library
 
     steps:
@@ -247,7 +248,7 @@ jobs:
     - name: Install prerequisites
       run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libspdlog-dev
+          sudo apt-get install -y libgtk-3-dev
 
     - name: Cache Catch
       uses: actions/cache@v3
@@ -311,6 +312,26 @@ jobs:
         cmake --build build --target install -j $(nproc)
         cd ..
 
+    - name: Cache spdlog
+      uses: actions/cache@v3
+      id: cache-spdlog
+      with:
+        path: spdlog/build/install
+        key: ${{runner.os}}-spdlog-${{env.SPDLOG_VERSION}}-${{env.BUILD_TYPE}}-20.04
+
+    - name: Install spdlog
+      if: steps.cache-spdlog.outputs.cache-hit != 'true'
+      run: |
+        git clone https://github.com/gabime/spdlog.git --depth 1 --branch $SPDLOG_VERSION
+        cd spdlog
+        cmake -B build \
+          -DCMAKE_C_COMPILER=gcc-10 \
+          -DCMAKE_CXX_COMPILER=g++-10 \
+          -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+          -DCMAKE_INSTALL_PREFIX=build/install
+        cmake --build build --target install -j $(nproc)
+        cd ..
+
     - name: Cache exiv2
       uses: actions/cache@v3
       id: cache-exiv2
@@ -343,7 +364,8 @@ jobs:
           -DCatch2_DIR=../catch/install/lib/cmake/Catch2 \
           -DOpenCV_DIR=opencv/install/lib/cmake/opencv4 \
           -DSDL2_DIR=SDL/install/lib/cmake/SDL2 \
-          -Dexiv2_DIR=exiv2/install/lib/cmake/exiv2
+          -Dexiv2_DIR=exiv2/install/lib/cmake/exiv2 \
+          -Dspdlog_DIR=`pwd`/spdlog/build/install/lib/cmake/spdlog
 
     - name: Build
       run: cmake --build build -j $(nproc) --target install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,18 +143,19 @@ jobs:
 
     - name: Configure CMake
       run: |
+        $cwd = (Get-Location).Path -replace "\\", "/"
         cmake -B build -G "$env:GENERATOR" `
           -DBUILD_TESTING=ON `
           -DXPANO_EXTRA_LICENSES=licenses `
           -DXPANO_STATIC_VCRT=ON `
           -DCMAKE_INSTALL_PREFIX=install `
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON `
-          -DSDL2_DIR="sdl/install/cmake" `
+          -DSDL2_DIR="${cwd}/sdl/install/cmake" `
           -DOpenCV_STATIC=ON `
-          -DOpenCV_DIR="opencv/install" `
-          -Dspdlog_DIR="spdlog/build/install/lib/cmake/spdlog" `
-          -DCatch2_DIR="../catch/install/lib/cmake/Catch2" `
-          -Dexiv2_DIR="exiv2/install/lib/cmake/exiv2"
+          -DOpenCV_DIR="${cwd}/opencv/install" `
+          -Dspdlog_DIR="${cwd}/spdlog/build/install/lib/cmake/spdlog" `
+          -DCatch2_DIR="${cwd}/catch/install/lib/cmake/Catch2" `
+          -Dexiv2_DIR="${cwd}/exiv2/install/lib/cmake/exiv2"
 
     - name: Build
       run: cmake --build build --config $env:BUILD_TYPE --target install

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "external/expected"]
 	path = external/expected
 	url = ../../TartanLlama/expected.git
+[submodule "external/multiblend"]
+	path = external/multiblend
+	url = ../multiblend.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,16 @@
 cmake_minimum_required(VERSION 3.21)
+project(Xpano)
+
+cmake_host_system_information(RESULT has_sse QUERY HAS_SSE)
+
 OPTION(BUILD_TESTING "Build tests" OFF)
+OPTION(XPANO_STATIC_VCRT "Build with static VCRT" OFF)
+OPTION(XPANO_WITH_MULTIBLEND "Build with multiblend" ${has_sse})
 
 if(XPANO_STATIC_VCRT)
   set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()
 
-project(Xpano)
 include(CTest)
 include("${CMAKE_SOURCE_DIR}/misc/cmake/utils.cmake")
 
@@ -20,7 +25,11 @@ add_subdirectory("external/alpaca" EXCLUDE_FROM_ALL)
 
 set(EXPECTED_BUILD_TESTS OFF) # needed to disable download of catch2
 add_subdirectory("external/expected" EXCLUDE_FROM_ALL)
-add_subdirectory("external/multiblend")
+
+if(XPANO_WITH_MULTIBLEND)
+  add_subdirectory("external/multiblend")
+  target_include_directories(MultiblendLib PRIVATE "external/thread-pool")
+endif()
 
 set(IMGUI_SOURCES 
   "external/imgui/imgui.cpp"
@@ -88,12 +97,12 @@ else()
   endif()
 endif()
 
-add_executable(Xpano
+add_executable(Xpano WIN32
   ${XPANO_SOURCES}
   ${IMGUI_SOURCES}
 )
 
-target_include_directories(Xpano PRIVATE 
+target_include_directories(Xpano PRIVATE
   "external/imgui" 
   "external/imgui/backends"
   "external/thread-pool"
@@ -124,12 +133,16 @@ target_link_libraries(Xpano
   SDL2::SDL2
   SDL2::SDL2main
   spdlog::spdlog
-  MultiblendLib
 )
 
 if(exiv2_FOUND)
   target_compile_definitions(Xpano PRIVATE XPANO_WITH_EXIV2)
   target_link_libraries(Xpano exiv2lib)
+endif()
+
+if(XPANO_WITH_MULTIBLEND)
+  target_compile_definitions(Xpano PRIVATE XPANO_WITH_MULTIBLEND)
+  target_link_libraries(Xpano MultiblendLib)
 endif()
 
 copy_runtime_dlls(Xpano)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ add_subdirectory("external/alpaca" EXCLUDE_FROM_ALL)
 
 set(EXPECTED_BUILD_TESTS OFF) # needed to disable download of catch2
 add_subdirectory("external/expected" EXCLUDE_FROM_ALL)
+add_subdirectory("external/multiblend")
 
 set(IMGUI_SOURCES 
   "external/imgui/imgui.cpp"
@@ -37,6 +38,7 @@ set(XPANO_SOURCES
   "xpano/algorithm/auto_crop.cc"
   "xpano/algorithm/bundle_adjuster.cc"
   "xpano/algorithm/image.cc"
+  "xpano/algorithm/multiblend.cc"
   "xpano/algorithm/options.cc"
   "xpano/cli/args.cc"
   "xpano/cli/pano_cli.cc"
@@ -86,7 +88,7 @@ else()
   endif()
 endif()
 
-add_executable(Xpano WIN32
+add_executable(Xpano
   ${XPANO_SOURCES}
   ${IMGUI_SOURCES}
 )
@@ -114,7 +116,7 @@ if(NOT TARGET SDL2::SDL2main)
   add_library(SDL2::SDL2main INTERFACE IMPORTED)
 endif()
 
-target_link_libraries(Xpano
+target_link_libraries(Xpano WIN32
   alpaca
   expected
   nfd
@@ -122,6 +124,7 @@ target_link_libraries(Xpano
   SDL2::SDL2
   SDL2::SDL2main
   spdlog::spdlog
+  MultiblendLib
 )
 
 if(exiv2_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ if(NOT TARGET SDL2::SDL2main)
   add_library(SDL2::SDL2main INTERFACE IMPORTED)
 endif()
 
-target_link_libraries(Xpano WIN32
+target_link_libraries(Xpano
   alpaca
   expected
   nfd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,6 +245,18 @@ if (exiv2_FOUND)
     DESTINATION "${CMAKE_INSTALL_DATADIR}/licenses"
   )
 endif()
+if (XPANO_WITH_MULTIBLEND)
+  install(FILES
+    "external/multiblend/COPYRIGHT"
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/licenses"
+    RENAME "multiblend-notice.txt"
+  )
+  install(FILES
+    "external/multiblend/LICENSE"
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/licenses"
+    RENAME "multiblend-license.txt"
+  )
+endif()
 if(DEFINED XPANO_EXTRA_LICENSES)
   install(DIRECTORY
     "${XPANO_EXTRA_LICENSES}"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Xpano is a tool for panorama stitching with focus on simplicity and ease of use,
 
 The app uses the excellent [OpenCV](https://opencv.org/) library for image manipulation and its [stitching](https://docs.opencv.org/4.x/d1/d46/group__stitching.html) module for computing the panoramas.
 
-Other dependencies include [imgui](https://github.com/ocornut/imgui), [SDL](https://github.com/libsdl-org/SDL), [spdlog](https://github.com/gabime/spdlog/), [Catch2](https://github.com/catchorg/Catch2), [nativefiledialog-extended](https://github.com/btzy/nativefiledialog-extended), [alpaca](https://github.com/p-ranav/alpaca), [thread-pool](https://github.com/bshoshany/thread-pool), [expected](https://github.com/TartanLlama/expected), [Exiv2](https://github.com/Exiv2/exiv2) and the [Google Noto](https://fonts.google.com/noto) fonts.
+Other dependencies include [imgui](https://github.com/ocornut/imgui), [SDL](https://github.com/libsdl-org/SDL), [spdlog](https://github.com/gabime/spdlog/), [Catch2](https://github.com/catchorg/Catch2), [nativefiledialog-extended](https://github.com/btzy/nativefiledialog-extended), [alpaca](https://github.com/p-ranav/alpaca), [thread-pool](https://github.com/bshoshany/thread-pool), [expected](https://github.com/TartanLlama/expected), [Exiv2](https://github.com/Exiv2/exiv2), [multiblend](https://horman.net/multiblend/) and the [Google Noto](https://fonts.google.com/noto) fonts.
 
 ## Demo
 

--- a/misc/build/build-ubuntu-20.sh
+++ b/misc/build/build-ubuntu-20.sh
@@ -10,7 +10,7 @@ export GENERATOR='Ninja Multi-Config'
 
 git submodule update --init
 #sudo apt-get update
-#sudo apt-get install -y libgtk-3-dev libspdlog-dev
+#sudo apt-get install -y libgtk-3-dev
 
 
 git clone https://github.com/catchorg/Catch2.git catch --depth 1 --branch $CATCH_VERSION
@@ -48,6 +48,17 @@ cmake --build build --target install -j $(nproc)
 cd ..
 
 
+git clone https://github.com/gabime/spdlog.git --depth 1 --branch $SPDLOG_VERSION
+cd spdlog
+cmake -B build \
+  -DCMAKE_C_COMPILER=gcc-10 \
+  -DCMAKE_CXX_COMPILER=g++-10 \
+  -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+  -DCMAKE_INSTALL_PREFIX=build/install
+cmake --build build --target install -j $(nproc)
+cd ..
+
+
 git clone https://github.com/Exiv2/exiv2.git --depth 1 --branch $EXIV2_VERSION
 cd exiv2
 cmake -B build \
@@ -68,7 +79,8 @@ cmake -B build \
   -DCatch2_DIR=../catch/install/lib/cmake/Catch2 \
   -DOpenCV_DIR=opencv/install/lib/cmake/opencv4 \
   -DSDL2_DIR=SDL/install/lib/cmake/SDL2 \
-  -Dexiv2_DIR=exiv2/install/lib/cmake/exiv2
+  -Dexiv2_DIR=exiv2/install/lib/cmake/exiv2 \
+  -Dspdlog_DIR=`pwd`/spdlog/build/install/lib/cmake/spdlog
 
 cmake --build build -j $(nproc) --target install
 cd build

--- a/misc/build/build-windows-latest.ps1
+++ b/misc/build/build-windows-latest.ps1
@@ -67,18 +67,19 @@ Copy-Item "sdl/LICENSE.txt" -Destination "licenses/sdl-license.txt"
 Copy-Item "spdlog/LICENSE" -Destination "licenses/spdlog-license.txt"
 Copy-Item "exiv2/COPYING" -Destination "licenses/exiv2-license.txt"
 
+$cwd = (Get-Location).Path -replace "\\", "/"
 cmake -B build -G "$env:GENERATOR" `
   -DBUILD_TESTING=ON `
   -DXPANO_EXTRA_LICENSES=licenses `
   -DXPANO_STATIC_VCRT=ON `
   -DCMAKE_INSTALL_PREFIX=install `
   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON `
-  -DSDL2_DIR="sdl/install/cmake" `
+  -DSDL2_DIR="${cwd}/sdl/install/cmake" `
   -DOpenCV_STATIC=ON `
-  -DOpenCV_DIR="opencv/install" `
-  -Dspdlog_DIR="spdlog/build/install/lib/cmake/spdlog" `
-  -DCatch2_DIR="../catch/install/lib/cmake/Catch2" `
-  -Dexiv2_DIR="exiv2/install/lib/cmake/exiv2"
+  -DOpenCV_DIR="${cwd}/opencv/install" `
+  -Dspdlog_DIR="${cwd}/spdlog/build/install/lib/cmake/spdlog" `
+  -DCatch2_DIR="${cwd}/catch/install/lib/cmake/Catch2" `
+  -Dexiv2_DIR="${cwd}/exiv2/install/lib/cmake/exiv2"
 
 cmake --build build --config $env:BUILD_TYPE --target install
 cd build

--- a/misc/site/index.md
+++ b/misc/site/index.md
@@ -23,7 +23,7 @@ This is how the app looks after importing a directory of 200 images.
 
 The app uses the excellent [OpenCV](https://opencv.org/) library for image manipulation and its [stitching](https://docs.opencv.org/4.x/d1/d46/group__stitching.html) module for computing the panoramas.
 
-Other dependencies include [imgui](https://github.com/ocornut/imgui), [SDL](https://github.com/libsdl-org/SDL), [spdlog](https://github.com/gabime/spdlog/), [Catch2](https://github.com/catchorg/Catch2), [nativefiledialog-extended](https://github.com/btzy/nativefiledialog-extended), [alpaca](https://github.com/p-ranav/alpaca), [thread-pool](https://github.com/bshoshany/thread-pool), [expected](https://github.com/TartanLlama/expected), [Exiv2](https://github.com/Exiv2/exiv2) and the [Google Noto](https://fonts.google.com/noto) fonts.
+Other dependencies include [imgui](https://github.com/ocornut/imgui), [SDL](https://github.com/libsdl-org/SDL), [spdlog](https://github.com/gabime/spdlog/), [Catch2](https://github.com/catchorg/Catch2), [nativefiledialog-extended](https://github.com/btzy/nativefiledialog-extended), [alpaca](https://github.com/p-ranav/alpaca), [thread-pool](https://github.com/bshoshany/thread-pool), [expected](https://github.com/TartanLlama/expected), [Exiv2](https://github.com/Exiv2/exiv2), [multiblend](https://horman.net/multiblend/) and the [Google Noto](https://fonts.google.com/noto) fonts.
 
 ## Download
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,7 +38,6 @@ target_link_libraries(StitcherTest
   Catch2::Catch2WithMain
   ${OPENCV_TARGETS}
   spdlog::spdlog
-  MultiblendLib
 )
 
 if(exiv2_FOUND)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(StitcherTest
   ../xpano/algorithm/bundle_adjuster.cc
   ../xpano/algorithm/auto_crop.cc
   ../xpano/algorithm/image.cc
+  ../xpano/algorithm/multiblend.cc
   ../xpano/algorithm/options.cc
   ../xpano/pipeline/options.cc
   ../xpano/pipeline/stitcher_pipeline.cc
@@ -37,6 +38,7 @@ target_link_libraries(StitcherTest
   Catch2::Catch2WithMain
   ${OPENCV_TARGETS}
   spdlog::spdlog
+  MultiblendLib
 )
 
 if(exiv2_FOUND)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,11 @@ if(exiv2_FOUND)
   target_link_libraries(StitcherTest exiv2lib)
 endif()
 
+if(XPANO_WITH_MULTIBLEND)
+  target_compile_definitions(StitcherTest PRIVATE XPANO_WITH_MULTIBLEND)
+  target_link_libraries(StitcherTest MultiblendLib)
+endif()
+
 target_include_directories(StitcherTest PRIVATE 
   ".."
   "../external/thread-pool"

--- a/xpano/algorithm/algorithm.cc
+++ b/xpano/algorithm/algorithm.cc
@@ -8,6 +8,7 @@
 #include <iterator>
 #include <numeric>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -120,10 +121,16 @@ cv::detail::WaveCorrectKind PickWaveCorrectKind(
 
 cv::Ptr<cv::detail::Blender> PickBlender(BlendingMethod blending_method) {
   switch (blending_method) {
-    case BlendingMethod::kOpenCV:
+    case BlendingMethod::kOpenCV: {
       return cv::makePtr<cv::detail::MultiBandBlender>();
-    case BlendingMethod::kMultiblend:
-      return cv::makePtr<mb::MultiblendBlender>();
+    }
+    case BlendingMethod::kMultiblend: {
+      if constexpr (mb::Enabled()) {
+        return cv::makePtr<mb::MultiblendBlender>();
+      }
+      throw std::runtime_error(
+          "Multiblend is not supported in this build of xpano");
+    }
     default:
       return nullptr;
   }

--- a/xpano/algorithm/algorithm.h
+++ b/xpano/algorithm/algorithm.h
@@ -16,6 +16,7 @@
 #include "xpano/algorithm/options.h"
 #include "xpano/constants.h"
 #include "xpano/utils/rect.h"
+#include "xpano/utils/threadpool.h"
 
 namespace xpano::algorithm {
 
@@ -45,7 +46,7 @@ struct StitchResult {
 };
 
 StitchResult Stitch(const std::vector<cv::Mat>& images, StitchOptions options,
-                    bool return_pano_mask);
+                    bool return_pano_mask, utils::mt::Threadpool* threadpool);
 
 std::string ToString(cv::Stitcher::Status& status);
 

--- a/xpano/algorithm/multiblend.cc
+++ b/xpano/algorithm/multiblend.cc
@@ -7,6 +7,7 @@
 
 #ifdef XPANO_WITH_MULTIBLEND
 #include <mb/multiblend.h>
+#include <mb/threadpool.h>
 #endif
 #include <spdlog/fmt/fmt.h>
 
@@ -67,8 +68,9 @@ void MultiblendBlender::blend(cv::InputOutputArray dst,
                               cv::InputOutputArray dst_mask) {
 #ifdef XPANO_WITH_MULTIBLEND
   auto result = multiblend::Multiblend(
-      images_, {.output_type = multiblend::io::ImageType::MB_IN_MEMORY,
-                .output_bpp = 8});
+      images_,
+      {.output_type = multiblend::io::ImageType::MB_IN_MEMORY, .output_bpp = 8},
+      multiblend::mt::ThreadpoolPtr{threadpool_});
 
   if (result.width != dst_mask_.cols || result.height != dst_mask_.rows) {
     throw(std::runtime_error(fmt::format(

--- a/xpano/algorithm/multiblend.cc
+++ b/xpano/algorithm/multiblend.cc
@@ -5,7 +5,9 @@
 
 #include <stdexcept>
 
+#ifdef XPANO_WITH_MULTIBLEND
 #include <mb/multiblend.h>
+#endif
 #include <spdlog/fmt/fmt.h>
 
 namespace xpano::algorithm::mb {
@@ -18,6 +20,7 @@ void MultiblendBlender::prepare(cv::Rect dst_roi) {
 
 void MultiblendBlender::feed(cv::InputArray input_img,
                              cv::InputArray input_mask, cv::Point tl) {
+#ifdef XPANO_WITH_MULTIBLEND
   CV_Assert(input_img.type() == CV_16SC3);
   CV_Assert(input_mask.type() == CV_8U);
 
@@ -55,10 +58,14 @@ void MultiblendBlender::feed(cv::InputArray input_img,
   }
 
   images_.emplace_back(std::move(mb_image));
+#else
+  throw(std::runtime_error("Multiblend support not compiled in"));
+#endif
 }
 
 void MultiblendBlender::blend(cv::InputOutputArray dst,
                               cv::InputOutputArray dst_mask) {
+#ifdef XPANO_WITH_MULTIBLEND
   auto result = multiblend::Multiblend(
       images_, {.output_type = multiblend::io::ImageType::MB_IN_MEMORY,
                 .output_bpp = 8});
@@ -87,6 +94,9 @@ void MultiblendBlender::blend(cv::InputOutputArray dst,
 
   dst.assign(pano);
   dst_mask.assign(dst_mask_);
+#else
+  throw(std::runtime_error("Multiblend support not compiled in"));
+#endif
 }
 
 }  // namespace xpano::algorithm::mb

--- a/xpano/algorithm/multiblend.cc
+++ b/xpano/algorithm/multiblend.cc
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2023 Tomas Krupka
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "xpano/algorithm/multiblend.h"
+
+#include <stdexcept>
+
+#include <mb/multiblend.h>
+#include <spdlog/fmt/fmt.h>
+
+namespace xpano::algorithm::mb {
+
+void MultiblendBlender::prepare(cv::Rect dst_roi) {
+  dst_mask_.create(dst_roi.size(), CV_8U);
+  dst_mask_.setTo(cv::Scalar::all(0));
+  dst_roi_ = dst_roi;
+}
+
+void MultiblendBlender::feed(cv::InputArray input_img,
+                             cv::InputArray input_mask, cv::Point tl) {
+  CV_Assert(input_img.type() == CV_16SC3);
+  CV_Assert(input_mask.type() == CV_8U);
+
+  auto mb_image = multiblend::io::InMemoryImage{.tiff_width = input_img.cols(),
+                                                .tiff_height = input_img.rows(),
+                                                .bpp = 8,
+                                                .spp = 3,
+                                                .xpos_add = tl.x,
+                                                .ypos_add = tl.y,
+                                                .data = {}};
+
+  cv::Mat mask = input_mask.getMat();
+  cv::Mat dst_mask = dst_mask_.getMat(cv::ACCESS_RW);
+
+  int dx = tl.x - dst_roi_.x;
+  int dy = tl.y - dst_roi_.y;
+
+  cv::Mat img;
+  input_img.getMat().convertTo(img, CV_8UC3);
+  mb_image.data.resize(img.total() * img.elemSize());
+
+  uint8_t *mb_image_data = mb_image.data.data();
+  auto row_size = img.cols * img.elemSize();
+
+  for (int y = 0; y < img.rows; ++y, mb_image_data += row_size) {
+    const cv::Point3_<uint8_t> *src_row = img.ptr<cv::Point3_<uint8_t>>(y);
+    memcpy(mb_image_data, src_row, row_size);
+
+    const uint8_t *mask_row = mask.ptr<uint8_t>(y);
+    uint8_t *dst_mask_row = dst_mask.ptr<uint8_t>(dy + y);
+
+    for (int x = 0; x < img.cols; ++x) {
+      dst_mask_row[dx + x] |= mask_row[x];
+    }
+  }
+
+  images_.emplace_back(std::move(mb_image));
+}
+
+void MultiblendBlender::blend(cv::InputOutputArray dst,
+                              cv::InputOutputArray dst_mask) {
+  auto result = multiblend::Multiblend(
+      images_, {.output_type = multiblend::io::ImageType::MB_IN_MEMORY,
+                .output_bpp = 8});
+
+  if (result.width != dst_mask_.cols || result.height != dst_mask_.rows) {
+    throw(std::runtime_error(fmt::format(
+        "Multiblend returned an image of size {}x{}, expected {}x{}",
+        result.width, result.height, dst_mask_.cols, dst_mask_.rows)));
+  }
+
+  auto blue = cv::Mat(result.height, result.width, CV_8UC1,
+                      result.output_channels[0].get());
+  auto green = cv::Mat(result.height, result.width, CV_8UC1,
+                       result.output_channels[1].get());
+  auto red = cv::Mat(result.height, result.width, CV_8UC1,
+                     result.output_channels[2].get());
+
+  std::vector<cv::Mat> channels{blue, green, red};
+
+  cv::Mat pano;
+  cv::merge(channels, pano);
+
+  cv::UMat mask;
+  compare(dst_mask_, 0, mask, cv::CMP_EQ);
+  pano.setTo(cv::Scalar::all(0), mask);
+
+  dst.assign(pano);
+  dst_mask.assign(dst_mask_);
+}
+
+}  // namespace xpano::algorithm::mb

--- a/xpano/algorithm/multiblend.h
+++ b/xpano/algorithm/multiblend.h
@@ -8,6 +8,8 @@
 #endif
 #include <opencv2/stitching/detail/blenders.hpp>
 
+#include "xpano/utils/threadpool.h"
+
 namespace xpano::algorithm::mb {
 
 constexpr bool Enabled() {
@@ -20,6 +22,8 @@ constexpr bool Enabled() {
 
 class MultiblendBlender : public cv::detail::Blender {
  public:
+  MultiblendBlender(utils::mt::Threadpool* threadpool)
+      : threadpool_(threadpool) {}
   void prepare(cv::Rect dst_roi) override;
   void feed(cv::InputArray img, cv::InputArray mask, cv::Point tl) override;
   void blend(cv::InputOutputArray dst, cv::InputOutputArray dst_mask) override;
@@ -28,6 +32,7 @@ class MultiblendBlender : public cv::detail::Blender {
 #ifdef XPANO_WITH_MULTIBLEND
   std::vector<multiblend::io::Image> images_;
 #endif
+  utils::mt::Threadpool* threadpool_;
 };
 
 }  // namespace xpano::algorithm::mb

--- a/xpano/algorithm/multiblend.h
+++ b/xpano/algorithm/multiblend.h
@@ -3,10 +3,20 @@
 
 #include <vector>
 
+#ifdef XPANO_WITH_MULTIBLEND
 #include <mb/image.h>
+#endif
 #include <opencv2/stitching/detail/blenders.hpp>
 
 namespace xpano::algorithm::mb {
+
+constexpr bool Enabled() {
+#ifdef XPANO_WITH_MULTIBLEND
+  return true;
+#else
+  return false;
+#endif
+}
 
 class MultiblendBlender : public cv::detail::Blender {
  public:
@@ -15,7 +25,9 @@ class MultiblendBlender : public cv::detail::Blender {
   void blend(cv::InputOutputArray dst, cv::InputOutputArray dst_mask) override;
 
  private:
+#ifdef XPANO_WITH_MULTIBLEND
   std::vector<multiblend::io::Image> images_;
+#endif
 };
 
 }  // namespace xpano::algorithm::mb

--- a/xpano/algorithm/multiblend.h
+++ b/xpano/algorithm/multiblend.h
@@ -22,10 +22,11 @@ constexpr bool Enabled() {
 
 class MultiblendBlender : public cv::detail::Blender {
  public:
-  MultiblendBlender(utils::mt::Threadpool* threadpool)
+  explicit MultiblendBlender(utils::mt::Threadpool* threadpool)
       : threadpool_(threadpool) {}
   void prepare(cv::Rect dst_roi) override;
-  void feed(cv::InputArray img, cv::InputArray mask, cv::Point tl) override;
+  void feed(cv::InputArray img, cv::InputArray mask,
+            cv::Point top_left) override;
   void blend(cv::InputOutputArray dst, cv::InputOutputArray dst_mask) override;
 
  private:

--- a/xpano/algorithm/multiblend.h
+++ b/xpano/algorithm/multiblend.h
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2023 Tomas Krupka
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <vector>
+
+#include <mb/image.h>
+#include <opencv2/stitching/detail/blenders.hpp>
+
+namespace xpano::algorithm::mb {
+
+class MultiblendBlender : public cv::detail::Blender {
+ public:
+  void prepare(cv::Rect dst_roi) override;
+  void feed(cv::InputArray img, cv::InputArray mask, cv::Point tl) override;
+  void blend(cv::InputOutputArray dst, cv::InputOutputArray dst_mask) override;
+
+ private:
+  std::vector<multiblend::io::Image> images_;
+};
+
+}  // namespace xpano::algorithm::mb

--- a/xpano/algorithm/options.cc
+++ b/xpano/algorithm/options.cc
@@ -82,4 +82,15 @@ const char* Label(InpaintingMethod inpaint_method) {
   }
 }
 
+const char* Label(BlendingMethod blending_method) {
+  switch (blending_method) {
+    case BlendingMethod::kOpenCV:
+      return "OpenCV";
+    case BlendingMethod::kMultiblend:
+      return "Multiblend";
+    default:
+      return "Unknown";
+  }
+}
+
 }  // namespace xpano::algorithm

--- a/xpano/algorithm/options.h
+++ b/xpano/algorithm/options.h
@@ -33,10 +33,13 @@ enum class InpaintingMethod {
   kTelea,
 };
 
+enum class BlendingMethod { kOpenCV, kMultiblend };
+
 const char* Label(ProjectionType projection_type);
 const char* Label(FeatureType feature_type);
 const char* Label(WaveCorrectionType wave_correction_type);
 const char* Label(InpaintingMethod inpaint_method);
+const char* Label(BlendingMethod blending_method);
 
 bool HasAdvancedParameters(ProjectionType projection_type);
 
@@ -59,6 +62,9 @@ const auto kWaveCorrectionTypes =
 const auto kInpaintingMethods =
     std::array{InpaintingMethod::kNavierStokes, InpaintingMethod::kTelea};
 
+const auto kBlendingMethods =
+    std::array{BlendingMethod::kOpenCV, BlendingMethod::kMultiblend};
+
 /*****************************************************************************/
 
 struct ProjectionOptions {
@@ -72,6 +78,7 @@ struct StitchOptions {
   FeatureType feature = FeatureType::kSift;
   WaveCorrectionType wave_correction = WaveCorrectionType::kAuto;
   float match_conf = kDefaultMatchConf;
+  BlendingMethod blending_method = BlendingMethod::kOpenCV;
 };
 
 struct InpaintingOptions {

--- a/xpano/cli/signal.h
+++ b/xpano/cli/signal.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #ifdef _WIN32
+#define NOMINMAX
 #include <windows.h>
 #endif
 

--- a/xpano/gui/panels/sidebar.cc
+++ b/xpano/gui/panels/sidebar.cc
@@ -259,12 +259,28 @@ Action DrawWaveCorrectionOptions(
   return action;
 }
 
+Action DrawBlendingOptions(pipeline::StitchAlgorithmOptions* stitch_options) {
+  Action action{};
+  ImGui::Text("Blending:");
+  ImGui::SameLine();
+  utils::imgui::InfoMarker("(?)",
+                           "OpenCV: better seam finding\nMultiblend: better "
+                           "image detail and smoother image transitions");
+  ImGui::Spacing();
+  if (utils::imgui::ComboBox(&stitch_options->blending_method,
+                             algorithm::kBlendingMethods, "##blending_type")) {
+    action |= {ActionType::kRecomputePano};
+  }
+  return action;
+}
+
 Action DrawStitchOptionsMenu(pipeline::StitchAlgorithmOptions* stitch_options,
                              bool debug_enabled) {
   Action action{};
   if (ImGui::BeginMenu("Panorama stitching")) {
     action |= DrawProjectionOptions(stitch_options);
     action |= DrawWaveCorrectionOptions(stitch_options);
+    action |= DrawBlendingOptions(stitch_options);
 
     if (debug_enabled) {
       ImGui::SeparatorText("Debug");

--- a/xpano/gui/panels/sidebar.cc
+++ b/xpano/gui/panels/sidebar.cc
@@ -15,6 +15,7 @@
 
 #include "xpano/algorithm/algorithm.h"
 #include "xpano/algorithm/image.h"
+#include "xpano/algorithm/multiblend.h"
 #include "xpano/constants.h"
 #include "xpano/gui/action.h"
 #include "xpano/gui/panels/preview_pane.h"
@@ -261,6 +262,9 @@ Action DrawWaveCorrectionOptions(
 
 Action DrawBlendingOptions(pipeline::StitchAlgorithmOptions* stitch_options) {
   Action action{};
+  if constexpr (!algorithm::mb::Enabled()) {
+    return action;
+  }
   ImGui::Text("Blending:");
   ImGui::SameLine();
   utils::imgui::InfoMarker("(?)",

--- a/xpano/log/logger.cc
+++ b/xpano/log/logger.cc
@@ -72,6 +72,12 @@ void BufferSinkMt::flush_() {}
 
 Logger::Logger() : sink_(std::make_shared<BufferSinkMt>()) {}
 
+Logger::~Logger() {
+#ifdef XPANO_WITH_MULTIBLEND
+  multiblend::utils::SetLogger(nullptr);
+#endif
+}
+
 void Logger::RedirectSpdlogToGui(
     std::optional<std::filesystem::path> app_data_path) {
   std::vector<spdlog::sink_ptr> sinks;

--- a/xpano/log/logger.cc
+++ b/xpano/log/logger.cc
@@ -18,6 +18,10 @@
 #include <spdlog/sinks/stdout_sinks.h>
 #include <spdlog/spdlog.h>
 
+#ifdef XPANO_WITH_MULTIBLEND
+#include <mb/logging.h>
+#endif
+
 #include "xpano/constants.h"
 
 namespace xpano::logger {
@@ -86,6 +90,10 @@ void Logger::RedirectSpdlogToGui(
       std::make_shared<spdlog::logger>("XPano", sinks.begin(), sinks.end());
   logger->flush_on(spdlog::level::err);
   spdlog::set_default_logger(logger);
+
+#ifdef XPANO_WITH_MULTIBLEND
+  multiblend::utils::SetLogger(logger);
+#endif
 }
 
 const std::vector<std::string> &Logger::Log() {

--- a/xpano/log/logger.h
+++ b/xpano/log/logger.h
@@ -31,6 +31,13 @@ class BufferSinkMt final : public spdlog::sinks::base_sink<std::mutex> {
 class Logger {
  public:
   Logger();
+  ~Logger();
+
+  Logger(const Logger &) = delete;
+  Logger &operator=(const Logger &) = delete;
+  Logger(Logger &&) = delete;
+  Logger &operator=(Logger &&) = delete;
+
   const std::vector<std::string> &Log();
   void RedirectSpdlogToGui(std::optional<std::filesystem::path> app_data_path);
 

--- a/xpano/pipeline/stitcher_pipeline.h
+++ b/xpano/pipeline/stitcher_pipeline.h
@@ -11,7 +11,6 @@
 #include <string>
 #include <vector>
 
-#include <BS_thread_pool.hpp>
 #include <opencv2/core.hpp>
 #include <opencv2/stitching.hpp>
 
@@ -20,6 +19,7 @@
 #include "xpano/constants.h"
 #include "xpano/pipeline/options.h"
 #include "xpano/utils/rect.h"
+#include "xpano/utils/threadpool.h"
 
 namespace xpano::pipeline {
 
@@ -131,7 +131,7 @@ class StitcherPipeline {
   ProgressMonitor progress_;
 
   std::atomic<bool> cancel_tasks_ = false;
-  BS::thread_pool pool_;
+  utils::mt::Threadpool pool_;
 };
 
 }  // namespace xpano::pipeline

--- a/xpano/pipeline/stitcher_pipeline.h
+++ b/xpano/pipeline/stitcher_pipeline.h
@@ -4,11 +4,13 @@
 
 #pragma once
 
+#include <algorithm>
 #include <atomic>
 #include <filesystem>
 #include <future>
 #include <optional>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include <opencv2/core.hpp>
@@ -131,7 +133,8 @@ class StitcherPipeline {
   ProgressMonitor progress_;
 
   std::atomic<bool> cancel_tasks_ = false;
-  utils::mt::Threadpool pool_;
+  utils::mt::Threadpool pool_ = {
+      std::max(2U, std::thread::hardware_concurrency())};
 };
 
 }  // namespace xpano::pipeline

--- a/xpano/utils/threadpool.h
+++ b/xpano/utils/threadpool.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2023 Tomas Krupka
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <BS_thread_pool.hpp>
+
+namespace xpano::utils::mt {
+
+template <typename TResultType>
+using MultiFuture = BS::multi_future<TResultType>;
+
+using Threadpool = BS::thread_pool;
+
+}  // namespace xpano::utils::mt


### PR DESCRIPTION
Integrating https://horman.net/multiblend/ as a blending option:

![image](https://github.com/krupkat/xpano/assets/6817216/f8302f8e-1b2c-4b6f-9358-0c83279c7fd8)

Using this fork: https://github.com/krupkat/multiblend/ as a submodule.

Compared with the [OpenCV implementation](https://docs.opencv.org/4.x/d5/d4b/classcv_1_1detail_1_1MultiBandBlender.html) Multiblend produces better image detail and smoother transitions of images with different exposure.

OpenCV has better seam estimation (using graph cuts). It is potentially doable to pass the OpenCV masks to Multiblend.

Keeping the OpenCV version as the default for now.

Fixes #76