### PR TITLE
Feature multiblend with alpha

### DIFF
--- a/tests/stitcher_pipeline_test.cc
+++ b/tests/stitcher_pipeline_test.cc
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <catch2/matchers/catch_matchers_vector.hpp>
@@ -397,6 +398,10 @@ TEST_CASE("Malformed input") {
 
 #ifdef XPANO_WITH_MULTIBLEND
 TEST_CASE("Stitcher pipeline Multiblend") {
+  auto blending_method =
+      GENERATE(xpano::algorithm::BlendingMethod::kMultiblend,
+               xpano::algorithm::BlendingMethod::kMultiblendAlpha);
+
   xpano::pipeline::StitcherPipeline stitcher;
 
   auto result = stitcher.RunLoading(kInputs, {}, {}).get();
@@ -405,7 +410,7 @@ TEST_CASE("Stitcher pipeline Multiblend") {
 
   const float eps = 0.02;
   auto stitch_algorithm = xpano::pipeline::StitchAlgorithmOptions{
-      .blending_method = xpano::algorithm::BlendingMethod::kMultiblend};
+      .blending_method = blending_method};
 
   auto pano0 = stitcher
                    .RunStitching(result, {.pano_id = 0,

--- a/xpano/algorithm/algorithm.cc
+++ b/xpano/algorithm/algorithm.cc
@@ -126,9 +126,11 @@ cv::Ptr<cv::detail::Blender> PickBlender(BlendingMethod blending_method,
     case BlendingMethod::kOpenCV: {
       return cv::makePtr<cv::detail::MultiBandBlender>();
     }
+    case BlendingMethod::kMultiblendAlpha:
+      [[fallthrough]];
     case BlendingMethod::kMultiblend: {
       if constexpr (mb::Enabled()) {
-        return cv::makePtr<mb::MultiblendBlender>(threadpool);
+        return cv::makePtr<mb::MultiblendBlender>(threadpool, blending_method);
       }
       throw std::runtime_error(
           "Multiblend is not supported in this build of xpano");

--- a/xpano/algorithm/multiblend.cc
+++ b/xpano/algorithm/multiblend.cc
@@ -16,58 +16,166 @@ namespace xpano::algorithm::mb {
 
 namespace {
 constexpr int kChannelDepth = 8;
+constexpr uint32_t kFlagBit = 0x80000000u;
+constexpr uint32_t kWithoutFlag = 0x7fffffffu;
+constexpr uint8_t kMaskOn = 0xffu;
+constexpr uint8_t kMaskOff = 0x00u;
+
+void SafeMemset(uint8_t *ptr, uint8_t value, size_t num, const uint8_t *end) {
+  if (num == 0) {
+    throw(std::runtime_error("Multiblend: invalid mask format"));
+  }
+  if (ptr + num > end) {
+    throw(std::runtime_error("Multiblend: mask out of bounds"));
+  }
+  std::memset(ptr, value, num);
 }
 
+// Convert from Multiblend's Flex format to OpenCV's UMat.
+// Flex is a RLE format, leftmost bit is the mask flag, the rest is the length.
+cv::UMat ToUMat(multiblend::utils::Flex &flex) {
+  auto mask = cv::Mat(flex.height_, flex.width_, CV_8U);
+
+  flex.Start();
+
+  for (int y = 0; y < mask.rows; y++) {
+    auto *ptr = mask.ptr<uint8_t>(y);
+    auto *end = ptr + mask.cols;
+
+    while (ptr < end) {
+      auto length_with_flag = flex.ReadForwards32();
+      if ((length_with_flag & kFlagBit) != 0u) {
+        auto length = length_with_flag & kWithoutFlag;
+        SafeMemset(ptr, kMaskOn, length, end);
+        ptr += length;
+      } else {
+        SafeMemset(ptr, kMaskOff, length_with_flag, end);
+        ptr += length_with_flag;
+      }
+    }
+  }
+
+  return mask.getUMat(cv::ACCESS_READ);
+}
+
+template <typename TChannelType>
+cv::UMat Merge(const std::array<TChannelType, 3> &mb_channels, int width,
+               int height) {
+  auto blue = cv::Mat(height, width, CV_8UC1, mb_channels[0].get());
+  auto green = cv::Mat(height, width, CV_8UC1, mb_channels[1].get());
+  auto red = cv::Mat(height, width, CV_8UC1, mb_channels[2].get());
+
+  std::vector<cv::UMat> channels{blue.getUMat(cv::ACCESS_READ),
+                                 green.getUMat(cv::ACCESS_READ),
+                                 red.getUMat(cv::ACCESS_READ)};
+  cv::UMat pano;
+  cv::merge(channels, pano);
+  return pano;
+}
+
+std::vector<uint8_t> ToVector(const cv::Mat &img) {
+  CV_Assert(img.type() == CV_8UC4 || img.type() == CV_8UC3);
+
+  std::vector<uint8_t> result(img.total() * img.elemSize());
+
+  if (img.isContinuous()) {
+    std::memcpy(result.data(), img.data, result.size());
+    return result;
+  }
+
+  uint8_t *result_data = result.data();
+  auto row_size = img.cols * img.elemSize();
+  for (int y = 0; y < img.rows; ++y, result_data += row_size) {
+    const auto *src_row = img.ptr<uint8_t>(y);
+    std::memcpy(result_data, src_row, row_size);
+  }
+  return result;
+}
+
+cv::UMat Merge(cv::InputArray input_img, cv::InputArray input_mask) {
+  cv::UMat input_img_8bit;
+  input_img.getUMat().convertTo(input_img_8bit, CV_8UC3);
+
+  std::vector<cv::UMat> channels;
+  cv::split(input_img_8bit, channels);
+  input_img_8bit.release();
+
+  cv::UMat mask;
+  // Multiblend only works with the mask as binary, this conversion prevents
+  // artifacts where the mask is not 0 or 255.
+  cv::compare(input_mask, 0, mask, cv::CMP_NE);
+  channels.push_back(mask);
+
+  cv::UMat input_with_alpha;
+  cv::merge(channels, input_with_alpha);
+  return input_with_alpha;
+}
+
+}  // namespace
+
 void MultiblendBlender::prepare(cv::Rect dst_roi) {
-  dst_mask_.create(dst_roi.size(), CV_8U);
-  dst_mask_.setTo(cv::Scalar::all(0));
+  if (blending_method_ == BlendingMethod::kMultiblend) {
+    dst_mask_.create(dst_roi.size(), CV_8U);
+    dst_mask_.setTo(cv::Scalar::all(0));
+  }
   dst_roi_ = dst_roi;
 }
 
+// Note: better work with UMat whenever possible to get a speedup from OpenCL,
+// the inputs and outputs are already expected to be UMats in the Stitcher code.
 void MultiblendBlender::feed(cv::InputArray input_img,
                              cv::InputArray input_mask, cv::Point top_left) {
 #ifdef XPANO_WITH_MULTIBLEND
   CV_Assert(input_img.type() == CV_16SC3);
   CV_Assert(input_mask.type() == CV_8U);
 
-  constexpr int kNumChannels = 3;
-  auto mb_image = multiblend::io::InMemoryImage{.tiff_width = input_img.cols(),
-                                                .tiff_height = input_img.rows(),
-                                                .bpp = kChannelDepth,
-                                                .spp = kNumChannels,
-                                                .xpos_add = top_left.x,
-                                                .ypos_add = top_left.y,
-                                                .data = {}};
+  cv::UMat input_umat;
 
-  cv::Mat mask = input_mask.getMat();
-  cv::Mat dst_mask = dst_mask_.getMat(cv::ACCESS_RW);
-
-  int start_x = top_left.x - dst_roi_.x;
-  int start_y = top_left.y - dst_roi_.y;
-
-  cv::Mat img;
-  input_img.getMat().convertTo(img, CV_8UC3);
-  mb_image.data.resize(img.total() * img.elemSize());
-
-  uint8_t *mb_image_data = mb_image.data.data();
-  auto row_size = img.cols * img.elemSize();
-
-  for (int y = 0; y < img.rows; ++y, mb_image_data += row_size) {
-    const auto *src_row = img.ptr<uint8_t>(y);
-    std::memcpy(mb_image_data, src_row, row_size);
-
-    const auto *mask_row = mask.ptr<uint8_t>(y);
-    auto *dst_mask_row = dst_mask.ptr<uint8_t>(start_y + y);
-
-    for (int x = 0; x < img.cols; ++x) {
-      dst_mask_row[start_x + x] |= mask_row[x];
-    }
+  if (blending_method_ == BlendingMethod::kMultiblendAlpha) {
+    input_umat = Merge(input_img, input_mask);
+  } else if (blending_method_ == BlendingMethod::kMultiblend) {
+    input_img.getUMat().convertTo(input_umat, CV_8UC3);
+    feed_mask(input_mask, top_left);
+  } else {
+    throw(std::runtime_error("Multiblend: Invalid blending method"));
   }
 
-  images_.emplace_back(std::move(mb_image));
+  images_.emplace_back(multiblend::io::InMemoryImage{
+      .tiff_width = input_umat.cols,
+      .tiff_height = input_umat.rows,
+      .bpp = kChannelDepth,
+      .spp = static_cast<uint16_t>(input_umat.channels()),
+      .xpos_add = top_left.x,
+      .ypos_add = top_left.y,
+      .data = ToVector(input_umat.getMat(cv::ACCESS_READ))});
 #else
   throw(std::runtime_error("Multiblend support not compiled in"));
 #endif
+}
+
+void MultiblendBlender::feed_mask(cv::InputArray mask, cv::Point top_left) {
+  int start_x = top_left.x - dst_roi_.x;
+  int start_y = top_left.y - dst_roi_.y;
+
+  cv::Mat src_mask = mask.getMat();
+  cv::Mat dst_mask = dst_mask_.getMat(cv::ACCESS_RW);
+
+  for (int y = 0; y < src_mask.rows; ++y) {
+    if (start_y + y < 0 || start_y + y >= dst_mask.rows) {
+      throw(std::runtime_error("Multiblend: Invalid mask size"));
+    }
+
+    const auto *src_mask_row = src_mask.ptr<uint8_t>(y);
+    auto *dst_mask_row = dst_mask.ptr<uint8_t>(start_y + y);
+
+    if (start_x < 0 || start_x + src_mask.cols > dst_mask.cols) {
+      throw(std::runtime_error("Multiblend: Invalid mask size"));
+    }
+
+    for (int x = 0; x < src_mask.cols; ++x) {
+      dst_mask_row[start_x + x] |= src_mask_row[x];
+    }
+  }
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters): OpenCV API
@@ -80,30 +188,26 @@ void MultiblendBlender::blend(cv::InputOutputArray dst,
        .output_bpp = kChannelDepth},
       multiblend::mt::ThreadpoolPtr{threadpool_});
 
-  if (result.width != dst_mask_.cols || result.height != dst_mask_.rows) {
+  if (blending_method_ == BlendingMethod::kMultiblend &&
+      (result.width != dst_mask_.cols || result.height != dst_mask_.rows)) {
     throw(std::runtime_error(fmt::format(
-        "Multiblend returned an image of size {}x{}, expected {}x{}",
+        "Multiblend: Returned an image of size {}x{}, expected {}x{}",
         result.width, result.height, dst_mask_.cols, dst_mask_.rows)));
   }
 
-  auto blue = cv::Mat(result.height, result.width, CV_8UC1,
-                      result.output_channels[0].get());
-  auto green = cv::Mat(result.height, result.width, CV_8UC1,
-                       result.output_channels[1].get());
-  auto red = cv::Mat(result.height, result.width, CV_8UC1,
-                     result.output_channels[2].get());
+  auto pano = Merge(result.output_channels, result.width, result.height);
 
-  std::vector<cv::Mat> channels{blue, green, red};
+  if (blending_method_ == BlendingMethod::kMultiblendAlpha) {
+    dst_mask_ = ToUMat(result.full_mask);
+  }
 
-  cv::Mat pano;
-  cv::merge(channels, pano);
-
-  cv::UMat mask;
-  compare(dst_mask_, 0, mask, cv::CMP_EQ);
-  pano.setTo(cv::Scalar::all(0), mask);
+  cv::UMat zeroes;
+  cv::compare(dst_mask_, 0, zeroes, cv::CMP_EQ);
+  pano.setTo(cv::Scalar::all(0), zeroes);
 
   dst.assign(pano);
   dst_mask.assign(dst_mask_);
+  dst_mask_.release();
 #else
   throw(std::runtime_error("Multiblend support not compiled in"));
 #endif

--- a/xpano/algorithm/multiblend.cc
+++ b/xpano/algorithm/multiblend.cc
@@ -93,6 +93,7 @@ std::vector<uint8_t> ToVector(const cv::Mat &img) {
   return result;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 cv::UMat Merge(cv::InputArray input_img, cv::InputArray input_mask) {
   cv::UMat input_img_8bit;
   input_img.getUMat().convertTo(input_img_8bit, CV_8UC3);
@@ -136,7 +137,7 @@ void MultiblendBlender::feed(cv::InputArray input_img,
     input_umat = Merge(input_img, input_mask);
   } else if (blending_method_ == BlendingMethod::kMultiblend) {
     input_img.getUMat().convertTo(input_umat, CV_8UC3);
-    feed_mask(input_mask, top_left);
+    FeedMask(input_mask, top_left);
   } else {
     throw(std::runtime_error("Multiblend: Invalid blending method"));
   }
@@ -154,7 +155,8 @@ void MultiblendBlender::feed(cv::InputArray input_img,
 #endif
 }
 
-void MultiblendBlender::feed_mask(cv::InputArray mask, cv::Point top_left) {
+void MultiblendBlender::FeedMask(cv::InputArray mask,
+                                 const cv::Point &top_left) {
   int start_x = top_left.x - dst_roi_.x;
   int start_y = top_left.y - dst_roi_.y;
 

--- a/xpano/algorithm/multiblend.cc
+++ b/xpano/algorithm/multiblend.cc
@@ -7,6 +7,7 @@
 #include <stdexcept>
 
 #ifdef XPANO_WITH_MULTIBLEND
+#include <mb/flex.h>
 #include <mb/multiblend.h>
 #include <mb/threadpool.h>
 #endif
@@ -43,7 +44,7 @@ cv::UMat ToUMat(multiblend::utils::Flex &flex) {
     auto *end = ptr + mask.cols;
 
     while (ptr < end) {
-      auto length_with_flag = flex.ReadForwards32();
+      auto length_with_flag = flex.SafeReadForwards32();
       if ((length_with_flag & kFlagBit) != 0u) {
         auto length = length_with_flag & kWithoutFlag;
         SafeMemset(ptr, kMaskOn, length, end);

--- a/xpano/algorithm/multiblend.h
+++ b/xpano/algorithm/multiblend.h
@@ -8,6 +8,7 @@
 #endif
 #include <opencv2/stitching/detail/blenders.hpp>
 
+#include "xpano/algorithm/options.h"
 #include "xpano/utils/threadpool.h"
 
 namespace xpano::algorithm::mb {
@@ -22,18 +23,22 @@ constexpr bool Enabled() {
 
 class MultiblendBlender : public cv::detail::Blender {
  public:
-  explicit MultiblendBlender(utils::mt::Threadpool* threadpool)
-      : threadpool_(threadpool) {}
+  explicit MultiblendBlender(utils::mt::Threadpool* threadpool,
+                             BlendingMethod blending_method)
+      : threadpool_(threadpool), blending_method_(blending_method) {}
   void prepare(cv::Rect dst_roi) override;
   void feed(cv::InputArray img, cv::InputArray mask,
             cv::Point top_left) override;
   void blend(cv::InputOutputArray dst, cv::InputOutputArray dst_mask) override;
 
  private:
+  void feed_mask(cv::InputArray mask, cv::Point top_left);
+
 #ifdef XPANO_WITH_MULTIBLEND
   std::vector<multiblend::io::Image> images_;
 #endif
   utils::mt::Threadpool* threadpool_;
+  BlendingMethod blending_method_;
 };
 
 }  // namespace xpano::algorithm::mb

--- a/xpano/algorithm/multiblend.h
+++ b/xpano/algorithm/multiblend.h
@@ -32,7 +32,7 @@ class MultiblendBlender : public cv::detail::Blender {
   void blend(cv::InputOutputArray dst, cv::InputOutputArray dst_mask) override;
 
  private:
-  void feed_mask(cv::InputArray mask, cv::Point top_left);
+  void FeedMask(cv::InputArray mask, const cv::Point& top_left);
 
 #ifdef XPANO_WITH_MULTIBLEND
   std::vector<multiblend::io::Image> images_;

--- a/xpano/algorithm/options.cc
+++ b/xpano/algorithm/options.cc
@@ -89,7 +89,7 @@ const char* Label(BlendingMethod blending_method) {
     case BlendingMethod::kMultiblend:
       return "Multiblend";
     case BlendingMethod::kMultiblendAlpha:
-      return "MultiblendAlpha";
+      return "Multiblend (with alpha)";
     default:
       return "Unknown";
   }

--- a/xpano/algorithm/options.cc
+++ b/xpano/algorithm/options.cc
@@ -88,6 +88,8 @@ const char* Label(BlendingMethod blending_method) {
       return "OpenCV";
     case BlendingMethod::kMultiblend:
       return "Multiblend";
+    case BlendingMethod::kMultiblendAlpha:
+      return "MultiblendAlpha";
     default:
       return "Unknown";
   }

--- a/xpano/algorithm/options.h
+++ b/xpano/algorithm/options.h
@@ -33,7 +33,7 @@ enum class InpaintingMethod {
   kTelea,
 };
 
-enum class BlendingMethod { kOpenCV, kMultiblend };
+enum class BlendingMethod { kOpenCV, kMultiblend, kMultiblendAlpha };
 
 const char* Label(ProjectionType projection_type);
 const char* Label(FeatureType feature_type);
@@ -63,7 +63,8 @@ const auto kInpaintingMethods =
     std::array{InpaintingMethod::kNavierStokes, InpaintingMethod::kTelea};
 
 const auto kBlendingMethods =
-    std::array{BlendingMethod::kOpenCV, BlendingMethod::kMultiblend};
+    std::array{BlendingMethod::kOpenCV, BlendingMethod::kMultiblend,
+               BlendingMethod::kMultiblendAlpha};
 
 /*****************************************************************************/
 

--- a/xpano/gui/panels/sidebar.cc
+++ b/xpano/gui/panels/sidebar.cc
@@ -270,7 +270,7 @@ Action DrawBlendingOptions(pipeline::StitchAlgorithmOptions* stitch_options) {
   utils::imgui::InfoMarker(
       "(?)",
       "OpenCV: better seam finding\nMultiblend: better "
-      "image detail and smoother image transitions\nMultiblendAlpha: "
+      "image detail and smoother image transitions\nMultiblend (with alpha): "
       "Multiblend + OpenCV seam finding");
   ImGui::Spacing();
   if (utils::imgui::ComboBox(&stitch_options->blending_method,

--- a/xpano/gui/panels/sidebar.cc
+++ b/xpano/gui/panels/sidebar.cc
@@ -267,9 +267,11 @@ Action DrawBlendingOptions(pipeline::StitchAlgorithmOptions* stitch_options) {
   }
   ImGui::Text("Blending:");
   ImGui::SameLine();
-  utils::imgui::InfoMarker("(?)",
-                           "OpenCV: better seam finding\nMultiblend: better "
-                           "image detail and smoother image transitions");
+  utils::imgui::InfoMarker(
+      "(?)",
+      "OpenCV: better seam finding\nMultiblend: better "
+      "image detail and smoother image transitions\nMultiblendAlpha: "
+      "Multiblend + OpenCV seam finding");
   ImGui::Spacing();
   if (utils::imgui::ComboBox(&stitch_options->blending_method,
                              algorithm::kBlendingMethods, "##blending_type")) {

--- a/xpano/pipeline/options.h
+++ b/xpano/pipeline/options.h
@@ -15,7 +15,7 @@ namespace xpano::pipeline {
 //  - Major changes can be auto detected by alpaca reflection, but e.g.
 //    modifying the enums cannot, so bump the version number in this case.
 //  - Will result in reloading the default values when loading the config.
-constexpr int kOptionsVersion = 1;
+constexpr int kOptionsVersion = 2;
 
 enum class ChromaSubsampling {
   k444,


### PR DESCRIPTION
Add "Multiblend (with alpha)" blending option.
- this way multiblend uses the OpenCV optimized seams

Without optimized seams:
![base](https://github.com/krupkat/xpano/assets/6817216/de532a5d-b2f9-4204-92ca-a29acd4e3664)

With optimized seams:
![alpha](https://github.com/krupkat/xpano/assets/6817216/c9a129f1-8499-4c99-8346-5a1b58c3e4c9)
Images credit: @sguyader