### PR TITLE
Cancellation polish

### DIFF
--- a/xpano/algorithm/progress.cc
+++ b/xpano/algorithm/progress.cc
@@ -16,7 +16,10 @@ void ProgressMonitor::SetTaskType(ProgressType type) { type_ = type; }
 void ProgressMonitor::SetNumTasks(int num_tasks) { num_tasks_ = num_tasks; }
 
 ProgressReport ProgressMonitor::Report() const {
-  return {type_, done_, num_tasks_};
+  if (IsCancelled()) {
+    return {.type = ProgressType::kCancelling, .tasks_done = 0, .num_tasks = 0};
+  }
+  return {.type = type_, .tasks_done = done_, .num_tasks = num_tasks_};
 }
 
 void ProgressMonitor::NotifyTaskDone() { done_++; }

--- a/xpano/algorithm/progress.h
+++ b/xpano/algorithm/progress.h
@@ -23,7 +23,8 @@ enum class ProgressType {
   kStitchSeamsPrepare,
   kStitchSeamsFind,
   kStitchCompose,
-  kStitchBlend
+  kStitchBlend,
+  kCancelling
 };
 
 struct ProgressReport {

--- a/xpano/constants.h
+++ b/xpano/constants.h
@@ -94,4 +94,6 @@ constexpr int kMaxImageSizeForCLI = 8192;
 
 constexpr int kExifDefaultOrientation = 1;
 
+constexpr int kCancelAnimationFrameDuration = 128;
+
 }  // namespace xpano

--- a/xpano/gui/panels/sidebar.cc
+++ b/xpano/gui/panels/sidebar.cc
@@ -64,6 +64,8 @@ std::string ProgressLabel(pipeline::ProgressType type) {
       return "Composing pano";
     case pipeline::ProgressType::kStitchBlend:
       return "Blending";
+    case pipeline::ProgressType::kCancelling:
+      return "Cancelling";
   }
 }
 
@@ -389,6 +391,12 @@ void DrawProgressBar(pipeline::ProgressReport progress) {
   if (progress.tasks_done != progress.num_tasks) {
     label = fmt::format("{}: {:.0f}%", ProgressLabel(progress.type),
                         progress_ratio * max_percent);
+  }
+  if (progress.type == pipeline::ProgressType::kCancelling) {
+    static int iter = 0;
+    iter = (iter + 1) % kCancelAnimationFrameDuration;
+    const int num_dots = iter / 16;
+    label = ProgressLabel(progress.type) + std::string(num_dots, '.');
   }
   ImGui::ProgressBar(progress_ratio, ImVec2(-1.0f, 0.f), label.c_str());
 }

--- a/xpano/pipeline/stitcher_pipeline.h
+++ b/xpano/pipeline/stitcher_pipeline.h
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <deque>
 #include <filesystem>
 #include <future>
 #include <optional>
@@ -91,6 +92,10 @@ using GenericFuture =
 //  - this is used in the gui that is periodically checking GetReadyTask()
 // If run == RunTraits::kReturnFuture: returns the Task objects to the caller
 //  - this is used in the CLI and tests
+//
+// Whenever a new task is queued, the previous task is cancelled. The queue
+// serves the purpose of holding on to the resources of the cancelled tasks
+// until they are finished and can be safely deleted.
 template <RunTraits run = RunTraits::kOwnFuture>
 class StitcherPipeline {
  public:
@@ -141,7 +146,7 @@ class StitcherPipeline {
   utils::mt::Threadpool multiblend_pool_ = {
       std::max(2U, std::thread::hardware_concurrency() - 1)};
 
-  std::queue<Task<GenericFuture>> queue_;
+  std::deque<Task<GenericFuture>> queue_;
 };
 
 }  // namespace xpano::pipeline


### PR DESCRIPTION
Added a cancellation animation:

https://github.com/krupkat/xpano/assets/6817216/afd6b091-f776-4cec-8af5-0fd9ff7dafec

image credit: Steven from https://monarophotography.au/

Fixed StitcherPipeline queue logic, so that a cancelled task that hangs for a while doesn't block newly enqued tasks from finishing. Eventually all tasks should be fixed, so that they can hang for as little as possible (bundle adjustment mostly).

Enhances #73 