### PR TITLE
Feature detect stacks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(Xpano)
 OPTION(BUILD_TESTING "Build tests" OFF)
 OPTION(XPANO_STATIC_VCRT "Build with static VCRT" OFF)
 OPTION(XPANO_WITH_MULTIBLEND "Build with multiblend" ON)
+OPTION(XPANO_INSTALL_DESKTOP_FILES "Install desktop files" OFF)
 
 if(XPANO_STATIC_VCRT)
   set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
@@ -167,7 +168,7 @@ install(FILES
   TYPE BIN
 )
 
-if(CMAKE_INSTALL_PREFIX MATCHES "^/usr.*|^/app.*")
+if(XPANO_INSTALL_DESKTOP_FILES OR CMAKE_INSTALL_PREFIX MATCHES "^/usr.*|^/app.*")
   install(FILES
     "misc/build/linux/xpano.desktop"
     DESTINATION "${CMAKE_INSTALL_PREFIX}/share/applications"

--- a/tests/stitcher_pipeline_test.cc
+++ b/tests/stitcher_pipeline_test.cc
@@ -40,6 +40,9 @@ int CountNonZero(const cv::Mat& image) {
   return cv::countNonZero(image_gray);
 }
 
+// Clang-tidy doesn't like the macros
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+
 TEST_CASE("Stitcher pipeline defaults") {
   xpano::pipeline::StitcherPipeline<kReturnFuture> stitcher;
 
@@ -93,9 +96,6 @@ TEST_CASE("Stitcher pipeline defaults") {
   CHECK(total_pixels == non_zero_pixels);
 }
 
-// Clang-tidy doesn't like the macros
-// NOLINTBEGIN(readability-function-cognitive-complexity)
-
 TEST_CASE("Stitcher pipeline single pano matching") {
   xpano::pipeline::StitcherPipeline<kReturnFuture> stitcher;
   auto loading_task = stitcher.RunLoading(
@@ -133,8 +133,6 @@ TEST_CASE("Stitcher pipeline no matching") {
     REQUIRE(image.GetDescriptors().empty());
   }
 }
-
-// NOLINTEND(readability-function-cognitive-complexity)
 
 const std::vector<std::filesystem::path> kShuffledInputs = {
     "data/image01.jpg",  // Pano 1
@@ -532,3 +530,5 @@ TEST_CASE("Stitcher pipeline stack detection") {
   REQUIRE(result.panos.size() == 1);
   CHECK_THAT(result.panos[0].ids, Equals<int>({2, 3}));
 }
+
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/stitcher_pipeline_test.cc
+++ b/tests/stitcher_pipeline_test.cc
@@ -500,3 +500,35 @@ TEST_CASE("Stitcher pipeline polling") {
   CHECK_THAT(pano1->rows, WithinRel(976, eps));
   CHECK_THAT(pano1->cols, WithinRel(1335, eps));
 }
+
+const std::vector<std::filesystem::path> kInputsWithStack = {
+    "data/image01.jpg",  // Minimal shift
+    "data/image05.jpg",  // between images
+    "data/image06.jpg",
+    "data/image07.jpg",
+};
+
+TEST_CASE("Stitcher pipeline stack detection") {
+  const float min_shift = 0.2f;
+  xpano::pipeline::StitcherPipeline<kReturnFuture> stitcher;
+  auto loading_task =
+      stitcher.RunLoading(kInputsWithStack, {}, {.min_shift = min_shift});
+  auto result = loading_task.future.get();
+  auto progress = loading_task.progress->Report();
+  CHECK(progress.tasks_done == progress.num_tasks);
+
+  std::vector<xpano::algorithm::Match> good_matches;
+  std::copy_if(result.matches.begin(), result.matches.end(),
+               std::back_inserter(good_matches), [](const auto& match) {
+                 return match.matches.size() >= xpano::kDefaultMatchThreshold;
+               });
+
+  CHECK(result.images.size() == 4);
+
+  REQUIRE(good_matches.size() == 2);
+  CHECK(good_matches[0].avg_shift < min_shift);
+  CHECK(good_matches[1].avg_shift >= min_shift);
+
+  REQUIRE(result.panos.size() == 1);
+  CHECK_THAT(result.panos[0].ids, Equals<int>({2, 3}));
+}

--- a/xpano/algorithm/algorithm.h
+++ b/xpano/algorithm/algorithm.h
@@ -32,15 +32,16 @@ struct Match {
   int id1;
   int id2;
   std::vector<cv::DMatch> matches;
+  float avg_shift = 0.0f;
 };
 
 Pano SinglePano(int size);
 
-std::vector<cv::DMatch> MatchImages(const Image& img1, const Image& img2,
-                                    float match_conf);
+Match MatchImages(int img1_id, int img2_id, const Image& img1,
+                  const Image& img2, float match_conf);
 
 std::vector<Pano> FindPanos(const std::vector<Match>& matches,
-                            int match_threshold);
+                            int match_threshold, float min_shift);
 
 struct StitchResult {
   stitcher::Status status;

--- a/xpano/algorithm/image.cc
+++ b/xpano/algorithm/image.cc
@@ -84,6 +84,10 @@ cv::Mat Image::GetFullRes() const { return cv::imread(path_.string()); }
 cv::Mat Image::GetThumbnail() const { return thumbnail_; }
 cv::Mat Image::GetPreview() const { return preview_; }
 
+int Image::GetPreviewLongerSide() const {
+  return std::max(preview_.size[1], preview_.size[0]);
+}
+
 float Image::GetAspect() const {
   auto width = static_cast<float>(preview_.size[1]);
   auto height = static_cast<float>(preview_.size[0]);

--- a/xpano/algorithm/image.h
+++ b/xpano/algorithm/image.h
@@ -26,6 +26,7 @@ class Image {
   [[nodiscard]] cv::Mat GetFullRes() const;
   [[nodiscard]] cv::Mat GetThumbnail() const;
   [[nodiscard]] cv::Mat GetPreview() const;
+  [[nodiscard]] int GetPreviewLongerSide() const;
   [[nodiscard]] float GetAspect() const;
   [[nodiscard]] cv::Mat Draw(bool show_debug) const;
   [[nodiscard]] const std::vector<cv::KeyPoint>& GetKeypoints() const;

--- a/xpano/constants.h
+++ b/xpano/constants.h
@@ -17,6 +17,10 @@ constexpr int kMinMatchThreshold = 4;
 constexpr int kDefaultMatchThreshold = 70;
 constexpr int kMaxMatchThreshold = 250;
 
+constexpr float kMinShiftInPano = 0.0f;
+constexpr float kDefaultShiftInPano = 0.1f;
+constexpr float kMaxShiftInPano = 1.0f;
+
 constexpr int kWindowWidth = 1280;
 constexpr int kWindowHeight = 800;
 constexpr int kMinWindowSize = 200;

--- a/xpano/gui/panels/sidebar.cc
+++ b/xpano/gui/panels/sidebar.cc
@@ -193,9 +193,9 @@ void DrawMatchingOptionsMenu(pipeline::MatchingOptions* matching_options,
       ImGui::Spacing();
       ImGui::Text(
           "Experiment with this if the app cannot find the panoramas you "
-          "want.");
+          "want.\nThese options are applied only after reloading images.");
       ImGui::Spacing();
-      ImGui::SliderInt("Matching distance",
+      ImGui::SliderInt("Matching neighbors",
                        &matching_options->neighborhood_search_size, 0,
                        kMaxNeighborhoodSearchSize);
       ImGui::SameLine();
@@ -210,6 +210,15 @@ void DrawMatchingOptionsMenu(pipeline::MatchingOptions* matching_options,
                                "Number of keypoints that need to match in "
                                "order to include the two "
                                "images in a panorama.");
+      ImGui::SliderFloat("Minimum shift", &matching_options->min_shift,
+                         kMinShiftInPano, kMaxShiftInPano, "%.2f");
+      ImGui::SameLine();
+      utils::imgui::InfoMarker(
+          "(?)",
+          "Minimum shift between images for it to be considered a part of a "
+          "panorama.\nUseful to filter out burst shots / focus stacks that "
+          "shouldn't be handled by Xpano.\nThe value is specified in relative "
+          "terms to the size of the image.");
       if (debug_enabled) {
         ImGui::SeparatorText("Debug");
         DrawMatchConf(&matching_options->match_conf);

--- a/xpano/gui/pano_gui.cc
+++ b/xpano/gui/pano_gui.cc
@@ -433,6 +433,7 @@ Action PanoGui::PerformAction(const Action& action) {
       selection_ = {SelectionType::kMatch, action.target_id};
       spdlog::info("Clicked match {}", action.target_id);
       const auto& match = stitcher_data_->matches[action.target_id];
+      spdlog::info("Match distance {}", match.avg_shift);
       auto img = DrawMatches(match, stitcher_data_->images);
       plot_pane_.Load(img, ImageType::kMatch);
       thumbnail_pane_.SetScrollX(match.id1, match.id2);

--- a/xpano/pipeline/options.h
+++ b/xpano/pipeline/options.h
@@ -59,6 +59,7 @@ struct MatchingOptions {
   MatchingType type = MatchingType::kAuto;
   int neighborhood_search_size = kDefaultNeighborhoodSearchSize;
   int match_threshold = kDefaultMatchThreshold;
+  float min_shift = kDefaultShiftInPano;
   float match_conf = kDefaultMatchConf;
 };
 

--- a/xpano/pipeline/stitcher_pipeline.cc
+++ b/xpano/pipeline/stitcher_pipeline.cc
@@ -175,8 +175,7 @@ StitcherData RunMatchingPipeline(std::vector<algorithm::Image> images,
       matches_future.push_back(
           pool->submit([i, j, left = images[i], right = images[j],
                         match_conf = options.match_conf, progress]() {
-            auto match =
-                algorithm::Match{i, j, MatchImages(left, right, match_conf)};
+            auto match = algorithm::MatchImages(i, j, left, right, match_conf);
             progress->NotifyTaskDone();
             return match;
           }));
@@ -188,7 +187,7 @@ StitcherData RunMatchingPipeline(std::vector<algorithm::Image> images,
   }
   auto matches = matches_future.get();
 
-  auto panos = FindPanos(matches, options.match_threshold);
+  auto panos = FindPanos(matches, options.match_threshold, options.min_shift);
   progress->NotifyTaskDone();
   return StitcherData{images, matches, panos};
 }


### PR DESCRIPTION
Detect image stacks from bracketing / focus stacking that shouldn't be handled by Xpano and skip them in automatic panorama detection.

![image](https://github.com/krupkat/xpano/assets/6817216/0e290bf5-91c5-4eed-a6bc-edf71e856baf)
