### PR TITLE
Bugfix incomplete panos

### DIFF
--- a/tests/stitcher_pipeline_test.cc
+++ b/tests/stitcher_pipeline_test.cc
@@ -224,7 +224,7 @@ TEST_CASE("Incomplete pano") {
   auto stitching_task0 = stitcher.RunStitching(stitch_data, {.pano_id = 0});
   auto stitch_result0 = stitching_task0.future.get();
 
-  // TODO: fix, this is currently not equal
+  // TODO(krupkat): fix, this is currently not equal
   // progress = stitching_task0.progress->Report();
   // CHECK(progress.tasks_done == progress.num_tasks);
 

--- a/xpano/algorithm/algorithm.cc
+++ b/xpano/algorithm/algorithm.cc
@@ -272,10 +272,9 @@ StitchResult Stitch(const std::vector<cv::Mat>& images,
   stitcher::Status status;
 
   if (cameras &&
-      cameras->wave_correction_user == user_options.wave_correction &&
-      cameras->cameras.size() == images.size()) {
+      cameras->wave_correction_user == user_options.wave_correction) {
     stitcher->SetWaveCorrectKind(cameras->wave_correction_auto);
-    stitcher->SetTransform(images, cameras->cameras);
+    stitcher->SetTransform(images, cameras->cameras, cameras->component);
     status = stitcher->ComposePanorama(pano);
   } else {
     status = stitcher->Stitch(images, pano);
@@ -290,9 +289,9 @@ StitchResult Stitch(const std::vector<cv::Mat>& images,
     stitcher->ResultMask().copyTo(mask);
   }
 
-  auto result_cameras =
-      Cameras{stitcher->Cameras(), user_options.wave_correction,
-              stitcher->WaveCorrectKind(), stitcher->GetWarpHelper()};
+  auto result_cameras = Cameras{
+      stitcher->Cameras(), stitcher->Component(), user_options.wave_correction,
+      stitcher->WaveCorrectKind(), stitcher->GetWarpHelper()};
   return {status, pano, mask, std::move(result_cameras)};
 }
 

--- a/xpano/algorithm/algorithm.h
+++ b/xpano/algorithm/algorithm.h
@@ -22,6 +22,7 @@ namespace xpano::algorithm {
 
 struct Cameras {
   std::vector<cv::detail::CameraParams> cameras;
+  std::vector<int> component;
   WaveCorrectionType wave_correction_user;           // set by user
   cv::detail::WaveCorrectKind wave_correction_auto;  // computed by OpenCV
   stitcher::WarpHelper warp_helper;

--- a/xpano/constants.h
+++ b/xpano/constants.h
@@ -56,7 +56,7 @@ constexpr int kMaxPngCompression = 9;
 
 constexpr int kAboutBoxWidth = 70;
 constexpr int kAboutBoxHeight = 30;
-constexpr int kSidebarWidth = 27;
+constexpr int kSidebarWidth = 35;
 constexpr int kWideButtonWidth = 12;
 
 const std::string kOrgName = "krupkat";

--- a/xpano/gui/action.h
+++ b/xpano/gui/action.h
@@ -48,6 +48,7 @@ struct ShowPanoExtra {
   bool full_res = false;
   bool scroll_thumbnails = false;
   bool reset_crop = false;
+  bool reset_cameras = false;
 };
 
 using LoadFilesExtra = std::vector<std::filesystem::path>;


### PR DESCRIPTION
When the user tried to stitch images where only a subset matched, the camera saving didn't work.
- fixed by additionally saving image indices with the camera parameters