### PR TITLE
Fix cropped export from preview

### DIFF
--- a/xpano/gui/pano_gui.cc
+++ b/xpano/gui/pano_gui.cc
@@ -586,12 +586,12 @@ void PanoGui::PerformExportAction(int pano_id) {
     return;
   }
 
+  const auto& pano = stitcher_data_->panos.at(pano_id);
   if (plot_pane_.Type() == ImageType::kPanoFullRes) {
     std::optional<std::filesystem::path> metadata_path;
     if (options_.metadata.copy_from_first_image) {
       metadata_path = first_image->GetPath();
     }
-    const auto& pano = stitcher_data_->panos.at(pano_id);
     stitcher_pipeline_.RunExport(plot_pane_.Image(),
                                  {.pano_id = pano_id,
                                   .export_path = *export_path,
@@ -603,6 +603,7 @@ void PanoGui::PerformExportAction(int pano_id) {
                                     {.pano_id = pano_id,
                                      .full_res = true,
                                      .export_path = *export_path,
+                                     .export_crop = pano.crop,
                                      .metadata = options_.metadata,
                                      .compression = options_.compression,
                                      .stitch_algorithm = options_.stitch});

--- a/xpano/pipeline/stitcher_pipeline.cc
+++ b/xpano/pipeline/stitcher_pipeline.cc
@@ -257,7 +257,8 @@ StitchingResult RunStitchingPipeline(
     export_path = RunExportPipeline(result,
                                     {.export_path = *options.export_path,
                                      .metadata_path = metadata_path,
-                                     .compression = options.compression},
+                                     .compression = options.compression,
+                                     .crop = options.export_crop},
                                     progress)
                       .export_path;
   }

--- a/xpano/pipeline/stitcher_pipeline.h
+++ b/xpano/pipeline/stitcher_pipeline.h
@@ -31,6 +31,7 @@ struct StitchingOptions {
   int pano_id = 0;
   bool full_res = false;
   std::optional<std::filesystem::path> export_path;
+  std::optional<utils::RectRRf> export_crop;
   MetadataOptions metadata;
   CompressionOptions compression;
   StitchAlgorithmOptions stitch_algorithm;

--- a/xpano/utils/vec_opencv.h
+++ b/xpano/utils/vec_opencv.h
@@ -5,6 +5,7 @@
 
 #include <opencv2/core.hpp>
 
+#include "xpano/utils/rect.h"
 #include "xpano/utils/vec.h"
 
 namespace xpano::utils {


### PR DESCRIPTION
When the user tried to export a cropped pano without calculating full res first, the crop was ignored.