### PR TITLE
Panorama downscaling

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   clang-format-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
 

--- a/misc/scripts/format.sh
+++ b/misc/scripts/format.sh
@@ -1,2 +1,2 @@
-clang-format-15 -i `find xpano -name *.cc -or -name *.h`
-clang-format-15 -i `find tests -name *.cc -or -name *.h`
+clang-format-18 -i `find xpano -name *.cc -or -name *.h`
+clang-format-18 -i `find tests -name *.cc -or -name *.h`

--- a/tests/stitcher_pipeline_test.cc
+++ b/tests/stitcher_pipeline_test.cc
@@ -26,6 +26,7 @@
 #include "xpano/algorithm/options.h"
 #include "xpano/algorithm/stitcher.h"
 #include "xpano/constants.h"
+#include "xpano/utils/opencv.h"
 #include "xpano/utils/rect.h"
 #include "xpano/utils/vec_opencv.h"
 
@@ -202,8 +203,8 @@ TEST_CASE("Pano too large") {
   REQUIRE(stitch_result1.status ==
           xpano::algorithm::stitcher::Status::kSuccessResolutionCapped);
 
-  CHECK_THAT(stitch_result1.pano->rows, WithinRel(1069, eps));
-  CHECK_THAT(stitch_result1.pano->cols, WithinRel(14971, eps));
+  auto pano_mpx = xpano::utils::opencv::MPx(*stitch_result1.pano);
+  CHECK_THAT(pano_mpx, WithinRel(max_pano_mpx, eps));
 }
 
 const std::vector<std::filesystem::path> kInputsIncomplete = {

--- a/tests/vec_test.cc
+++ b/tests/vec_test.cc
@@ -87,8 +87,8 @@ TEST_CASE("Add") {
 
 template <typename TLeft, typename TRight, typename TResult = void>
 concept Addable = requires(TLeft lhs, TRight rhs, TResult result) {
-                    { lhs + rhs } -> std::same_as<TResult>;
-                  };
+  { lhs + rhs } -> std::same_as<TResult>;
+};
 
 TEST_CASE("Add type checks") {
   REQUIRE(Addable<Vec2f, Vec2f, Vec2f>);
@@ -124,8 +124,8 @@ TEST_CASE("Subtract") {
 
 template <typename TLeft, typename TRight, typename TResult = void>
 concept Subtractable = requires(TLeft lhs, TRight rhs, TResult result) {
-                         { lhs - rhs } -> std::same_as<TResult>;
-                       };
+  { lhs - rhs } -> std::same_as<TResult>;
+};
 
 TEST_CASE("Subtract type checks") {
   REQUIRE(Subtractable<Vec2f, Vec2f, Vec2f>);
@@ -191,8 +191,8 @@ TEST_CASE("Divide by Vec") {
 
 template <typename TLeft, typename TRight, typename TResult = void>
 concept Divisible = requires(TLeft lhs, TRight rhs, TResult result) {
-                      { lhs / rhs } -> std::same_as<TResult>;
-                    };
+  { lhs / rhs } -> std::same_as<TResult>;
+};
 
 TEST_CASE("Divide type checks") {
   SECTION("Divide by constant") {
@@ -280,8 +280,8 @@ TEST_CASE("Multiply by Ratio") {
 
 template <typename TLeft, typename TRight, typename TResult = void>
 concept Multiplicable = requires(TLeft lhs, TRight rhs, TResult result) {
-                          { lhs* rhs } -> std::same_as<TResult>;
-                        };
+  { lhs* rhs } -> std::same_as<TResult>;
+};
 
 TEST_CASE("Multiply type checks") {
   SECTION("Multiply by constant") {

--- a/xpano/algorithm/algorithm.cc
+++ b/xpano/algorithm/algorithm.cc
@@ -260,7 +260,7 @@ StitchResult Stitch(const std::vector<cv::Mat>& images,
       false, user_options.match_conf));
   stitcher->SetWaveCorrection(user_options.wave_correction !=
                               WaveCorrectionType::kOff);
-  stitcher->SetMaxPanoSize(user_options.max_pano_size);
+  stitcher->SetMaxPanoMpx(user_options.max_pano_mpx);
   if (stitcher->WaveCorrection()) {
     stitcher->SetWaveCorrectKind(
         PickWaveCorrectKind(user_options.wave_correction));

--- a/xpano/algorithm/algorithm.cc
+++ b/xpano/algorithm/algorithm.cc
@@ -281,7 +281,7 @@ StitchResult Stitch(const std::vector<cv::Mat>& images,
     status = stitcher->Stitch(images, pano);
   }
 
-  if (status != stitcher::Status::kSuccess) {
+  if (!IsSuccess(status)) {
     return {status, {}, {}};
   }
 
@@ -313,6 +313,8 @@ std::string ToString(stitcher::Status& status) {
   switch (status) {
     case stitcher::Status::kSuccess:
       return "OK";
+    case stitcher::Status::kSuccessResolutionCapped:
+      return "OK_resolution_capped";
     case stitcher::Status::kCancelled:
       return "Cancelled";
     case stitcher::Status::kErrNeedMoreImgs:

--- a/xpano/algorithm/algorithm.cc
+++ b/xpano/algorithm/algorithm.cc
@@ -296,12 +296,15 @@ StitchResult Stitch(const std::vector<cv::Mat>& images,
   return {status, pano, mask, std::move(result_cameras)};
 }
 
-int StitchTasksCount(int num_images) {
-  return 1 +           // find features
-         1 +           // match features
-         1 +           // estimate homography
-         1 +           // bundle adjustment
-         1 +           // compute pano size
+int StitchTasksCount(int num_images, bool cameras_precomputed) {
+  int tasks = 0;
+  if (!cameras_precomputed) {
+    tasks += 1 +  // find features
+             1 +  // match features
+             1 +  // estimate homography
+             1;   // bundle adjustment
+  }
+  return tasks + 1 +   // compute pano size
          1 +           // prepare seams
          1 +           // find seams
          num_images +  // compose
@@ -323,8 +326,6 @@ std::string ToString(stitcher::Status& status) {
       return "ERR_HOMOGRAPHY_EST_FAIL";
     case stitcher::Status::kErrCameraParamsAdjustFail:
       return "ERR_CAMERA_PARAMS_ADJUST_FAIL";
-    case stitcher::Status::kErrPanoTooLarge:
-      return "ERR_PANO_TOO_LARGE\nReset the adjustments through the edit menu.";
     default:
       return "ERR_UNKNOWN";
   }

--- a/xpano/algorithm/algorithm.h
+++ b/xpano/algorithm/algorithm.h
@@ -69,7 +69,7 @@ StitchResult Stitch(const std::vector<cv::Mat>& images,
                     const std::optional<Cameras>& cameras,
                     StitchUserOptions user_options, StitchOptions options);
 
-int StitchTasksCount(int num_images);
+int StitchTasksCount(int num_images, bool cameras_precomputed);
 
 std::string ToString(stitcher::Status& status);
 

--- a/xpano/algorithm/options.h
+++ b/xpano/algorithm/options.h
@@ -84,7 +84,7 @@ struct StitchUserOptions {
   FeatureType feature = FeatureType::kSift;
   WaveCorrectionType wave_correction = WaveCorrectionType::kAuto;
   float match_conf = kDefaultMatchConf;
-  int max_pano_size = kMaxPanoSize;
+  int max_pano_mpx = kMaxPanoMpx;
   BlendingMethod blending_method = kDefaultBlendingMethod;
 };
 

--- a/xpano/algorithm/stitcher.cc
+++ b/xpano/algorithm/stitcher.cc
@@ -314,7 +314,7 @@ Status Stitcher::ComposePanorama(cv::OutputArray pano) {
   auto pano_mpx = utils::opencv::MPx(roi.rect);
 
   if (pano_mpx > max_pano_mpx_) {
-    float downscale_ratio = std::sqrt(max_pano_mpx_ / pano_mpx);
+    const float downscale_ratio = std::sqrt(max_pano_mpx_ / pano_mpx);
     warped_image_scale_ *= downscale_ratio;
 
     spdlog::warn(

--- a/xpano/algorithm/stitcher.cc
+++ b/xpano/algorithm/stitcher.cc
@@ -132,6 +132,46 @@ std::vector<TType> Index(const std::vector<TType> &vec,
   return subset;
 }
 
+struct Roi {
+  std::vector<cv::Point> corners;
+  std::vector<cv::Size> sizes;
+  cv::Ptr<cv::detail::RotationWarper> warper;
+  cv::Rect rect;
+};
+
+Roi ComputeRoi(const std::vector<cv::detail::CameraParams> &cameras_scaled,
+               std::vector<cv::Size> full_img_sizes,
+               const cv::Ptr<cv::WarperCreator> &warper_creater,
+               float warp_scale) {
+  spdlog::info("Calculating pano size... ");
+  // NextTask(ProgressType::kStitchComputeRoi);
+  auto compute_roi_timer = Timer();
+
+  std::vector<cv::Point> corners(cameras_scaled.size());
+  std::vector<cv::Size> sizes(cameras_scaled.size());
+
+  auto warper = warper_creater->create(warp_scale);
+
+  // Update corners and sizes
+  for (size_t i = 0; i < cameras_scaled.size(); ++i) {
+    auto k_float = utils::opencv::ToFloat(cameras_scaled[i].K());
+    const cv::Rect roi =
+        warper->warpRoi(full_img_sizes[i], k_float, cameras_scaled[i].R);
+    corners[i] = roi.tl();
+    sizes[i] = roi.size();
+  }
+
+  auto dst_roi = cv::detail::resultRoi(corners, sizes);
+
+  compute_roi_timer.Report(" compute pano size time");
+  return {corners, sizes, warper, dst_roi};
+}
+
+float MPx(const cv::Rect &rect) {
+  return static_cast<float>(rect.width) * static_cast<float>(rect.height) /
+         1e6f;
+}
+
 }  // namespace
 
 cv::Ptr<Stitcher> Stitcher::Create(Mode mode) {
@@ -265,36 +305,21 @@ Status Stitcher::ComposePanorama(cv::OutputArray pano) {
   auto compose_work_aspect = 1.0 / work_scale_;
   auto cameras_scaled = utils::opencv::Scale(cameras_, compose_work_aspect);
 
-  std::vector<cv::Point> corners(imgs_.size());
-  std::vector<cv::Size> sizes(imgs_.size());
+  auto warp_scale =
+      static_cast<float>(warped_image_scale_ * compose_work_aspect);
+  auto roi =
+      ComputeRoi(cameras_scaled, full_img_sizes_, warper_creater_, warp_scale);
+  auto pano_mpx = MPx(roi.rect);
 
-  cv::Ptr<cv::detail::RotationWarper> warper;
-  {
-    spdlog::info("Calculating pano size... ");
-    NextTask(ProgressType::kStitchComputeRoi);
-    auto compute_roi_timer = Timer();
+  if (pano_mpx > max_pano_mpx_) {
+    spdlog::warn(
+        "Panorama is too large to compute: {}x{} ({:.2f} Mpx), max size is {} "
+        "MPx",
+        roi.rect.width, roi.rect.height, pano_mpx, max_pano_mpx_);
 
-    // Update warped image scale
-    auto warp_scale =
-        static_cast<float>(warped_image_scale_ * compose_work_aspect);
-    warper = warper_creater_->create(warp_scale);
-
-    // Update corners and sizes
-    for (size_t i = 0; i < imgs_.size(); ++i) {
-      auto k_float = utils::opencv::ToFloat(cameras_scaled[i].K());
-      const cv::Rect roi =
-          warper->warpRoi(full_img_sizes_[i], k_float, cameras_scaled[i].R);
-      corners[i] = roi.tl();
-      sizes[i] = roi.size();
-    }
-    compute_roi_timer.Report(" compute pano size time");
-  }
-  auto dst_roi = cv::detail::resultRoi(corners, sizes);
-
-  if (dst_roi.width >= max_pano_size_ || dst_roi.height >= max_pano_size_) {
-    spdlog::error("Panorama is too large to compute: {}x{}, max size is {}",
-                  dst_roi.width, dst_roi.height, max_pano_size_);
-    return Status::kErrPanoTooLarge;
+    auto smaller_warp_scale = warp_scale * std::sqrt(max_pano_mpx_ / pano_mpx);
+    roi = ComputeRoi(cameras_scaled, full_img_sizes_, warper_creater_,
+                     smaller_warp_scale);
   }
 
   std::vector<cv::UMat> masks_warped;
@@ -317,7 +342,7 @@ Status Stitcher::ComposePanorama(cv::OutputArray pano) {
   spdlog::info("Compositing...");
   auto compositing_total_timer = Timer();
 
-  blender_->prepare(dst_roi);
+  blender_->prepare(roi.rect);
   for (size_t img_idx = 0; img_idx < imgs_.size(); ++img_idx) {
     NextTask(ProgressType::kStitchCompose);
     if (auto non_zero = cv::countNonZero(masks_warped[img_idx]);
@@ -337,19 +362,19 @@ Status Stitcher::ComposePanorama(cv::OutputArray pano) {
     auto timer = Timer();
 
     // Warp the current image
-    warper->warp(img, k_float, cameras_[img_idx].R, interp_flags_,
-                 cv::BORDER_REFLECT, img_warped);
+    roi.warper->warp(img, k_float, cameras_[img_idx].R, interp_flags_,
+                     cv::BORDER_REFLECT, img_warped);
     timer.Report(" warp the current image");
 
     // Warp the current image mask
     mask.create(img_size, CV_8U);
     mask.setTo(cv::Scalar::all(kMaskValueOn));
-    warper->warp(mask, k_float, cameras_[img_idx].R, cv::INTER_NEAREST,
-                 cv::BORDER_CONSTANT, mask_warped);
+    roi.warper->warp(mask, k_float, cameras_[img_idx].R, cv::INTER_NEAREST,
+                     cv::BORDER_CONSTANT, mask_warped);
     timer.Report(" warp the current image mask");
 
     // Compensate exposure
-    exposure_comp_->apply(static_cast<int>(img_idx), corners[img_idx],
+    exposure_comp_->apply(static_cast<int>(img_idx), roi.corners[img_idx],
                           img_warped, mask_warped);
     timer.Report(" compensate exposure");
 
@@ -365,7 +390,7 @@ Status Stitcher::ComposePanorama(cv::OutputArray pano) {
     timer.Report(" other");
 
     // Blend the current image
-    blender_->feed(img_warped, mask_warped, corners[img_idx]);
+    blender_->feed(img_warped, mask_warped, roi.corners[img_idx]);
     timer.Report(" feed time");
 
     compositing_timer.Report("Compositing ## time");
@@ -386,8 +411,8 @@ Status Stitcher::ComposePanorama(cv::OutputArray pano) {
 
   pano.assign(result);
 
-  warp_helper_ = {work_scale_, corners, sizes, full_img_sizes_,
-                  std::move(warper)};
+  warp_helper_ = {work_scale_, roi.corners, roi.sizes, full_img_sizes_,
+                  std::move(roi.warper)};
 
   EndMonitoring();
   return Status::kSuccess;

--- a/xpano/algorithm/stitcher.cc
+++ b/xpano/algorithm/stitcher.cc
@@ -314,14 +314,21 @@ Status Stitcher::ComposePanorama(cv::OutputArray pano) {
   auto pano_mpx = utils::opencv::MPx(roi.rect);
 
   if (pano_mpx > max_pano_mpx_) {
+    float downscale_ratio = std::sqrt(max_pano_mpx_ / pano_mpx);
+    warped_image_scale_ *= downscale_ratio;
+
     spdlog::warn(
         "Panorama is too large to compute: {}x{} ({:.2f} Mpx), max size is {} "
         "MPx",
         roi.rect.width, roi.rect.height, pano_mpx, max_pano_mpx_);
 
-    auto smaller_warp_scale = warp_scale * std::sqrt(max_pano_mpx_ / pano_mpx);
+    auto smaller_warp_scale =
+        static_cast<float>(warped_image_scale_ * compose_work_aspect);
     roi = ComputeRoi(cameras_scaled, full_img_sizes_, warper_creater_,
                      smaller_warp_scale);
+    spdlog::warn("Limiting panorama size to {}x{}", roi.rect.width,
+                 roi.rect.height);
+
     resolution_capped = true;
   }
 

--- a/xpano/algorithm/stitcher.h
+++ b/xpano/algorithm/stitcher.h
@@ -65,8 +65,7 @@ enum class Status {
   kCancelled,
   kErrNeedMoreImgs,
   kErrHomographyEstFail,
-  kErrCameraParamsAdjustFail,
-  kErrPanoTooLarge
+  kErrCameraParamsAdjustFail
 };
 
 bool IsSuccess(Status status);

--- a/xpano/algorithm/stitcher.h
+++ b/xpano/algorithm/stitcher.h
@@ -135,8 +135,9 @@ class Stitcher {
     features_matcher_ = features_matcher;
   }
 
-  [[nodiscard]] int MaxPanoSize() const { return max_pano_size_; }
-  void SetMaxPanoSize(int max_pano_size) { max_pano_size_ = max_pano_size; }
+  void SetMaxPanoMpx(int max_pano_mpx) {
+    max_pano_mpx_ = static_cast<float>(max_pano_mpx);
+  }
 
   [[nodiscard]] const cv::UMat& MatchingMask() const { return matching_mask_; }
   void SetMatchingMask(const cv::UMat& mask) {
@@ -275,7 +276,7 @@ class Stitcher {
 
   ProgressMonitor* monitor_ = nullptr;
   WarpHelper warp_helper_ = {};
-  int max_pano_size_;
+  float max_pano_mpx_;
 };
 
 }  // namespace xpano::algorithm::stitcher

--- a/xpano/algorithm/stitcher.h
+++ b/xpano/algorithm/stitcher.h
@@ -61,12 +61,15 @@ namespace xpano::algorithm::stitcher {
 
 enum class Status {
   kSuccess,
+  kSuccessResolutionCapped,
   kCancelled,
   kErrNeedMoreImgs,
   kErrHomographyEstFail,
   kErrCameraParamsAdjustFail,
   kErrPanoTooLarge
 };
+
+bool IsSuccess(Status status);
 
 struct WarpHelper {
   double work_scale;

--- a/xpano/constants.h
+++ b/xpano/constants.h
@@ -103,7 +103,6 @@ constexpr int kCancelAnimationFrameDuration = 128;
 const std::string kGithubIssuesLink = "https://github.com/krupkat/xpano/issues";
 const std::string kAuthorEmail = "tomas@krupkat.cz";
 
-constexpr int kMaxPanoSize = 16384;
-constexpr int kMaxPanoSizeStep = 256;
+constexpr int kMaxPanoMpx = 64;
 
 }  // namespace xpano

--- a/xpano/constants.h
+++ b/xpano/constants.h
@@ -103,6 +103,6 @@ constexpr int kCancelAnimationFrameDuration = 128;
 const std::string kGithubIssuesLink = "https://github.com/krupkat/xpano/issues";
 const std::string kAuthorEmail = "tomas@krupkat.cz";
 
-constexpr int kMaxPanoMpx = 64;
+constexpr int kMaxPanoMpx = 100;
 
 }  // namespace xpano

--- a/xpano/gui/action.h
+++ b/xpano/gui/action.h
@@ -34,6 +34,7 @@ enum class ActionType {
   kShowPano,
   kModifyPano,
   kRecomputePano,
+  kRecomputePanoFullRes,
   kQuit,
   kToggleDebugLog,
   kWarnInputConversion,

--- a/xpano/gui/panels/preview_pane.cc
+++ b/xpano/gui/panels/preview_pane.cc
@@ -220,8 +220,8 @@ Action PreviewPane::Draw(const std::string& message) {
   {
     std::optional<std::string> extra;
     if (image_type_ == ImageType::kPanoFullRes) {
-      extra =
-          fmt::format("[{:.1f} MPx]", utils::opencv::MPx(full_resolution_pano_));
+      extra = fmt::format("[{:.1f} MPx]",
+                          utils::opencv::MPx(full_resolution_pano_));
     }
     DrawMessage(window.start + utils::Vec2f{0.0f, window.size[1]}, message,
                 extra);

--- a/xpano/gui/panels/sidebar.cc
+++ b/xpano/gui/panels/sidebar.cc
@@ -335,9 +335,9 @@ Action DrawMaxPanoSizeOptions(
   Action action{};
   ImGui::Text("Max panorama size:");
   ImGui::Spacing();
-  if (ImGui::InputInt("Max panorama size", &stitch_options->max_pano_size,
-                      kMaxPanoSizeStep)) {
-    action |= {ActionType::kRecomputePano};
+  if (ImGui::InputInt("[MPx]",
+                      &stitch_options->max_pano_mpx)) {
+    stitch_options->max_pano_mpx = std::max(stitch_options->max_pano_mpx, 1);
   }
   return action;
 }
@@ -348,11 +348,11 @@ Action DrawStitchOptionsMenu(pipeline::StitchAlgorithmOptions* stitch_options,
   if (ImGui::BeginMenu("Panorama stitching")) {
     action |= DrawProjectionOptions(stitch_options);
     action |= DrawWaveCorrectionOptions(stitch_options);
+    action |= DrawMaxPanoSizeOptions(stitch_options);
 
     if (debug_enabled) {
       ImGui::SeparatorText("Debug");
       action |= DrawBlendingOptions(stitch_options);
-      action |= DrawMaxPanoSizeOptions(stitch_options);
       action |= DrawFeatureMatchingOptions(stitch_options);
 
       if (DrawMatchConf(&stitch_options->match_conf)) {

--- a/xpano/gui/panels/sidebar.cc
+++ b/xpano/gui/panels/sidebar.cc
@@ -336,6 +336,10 @@ Action DrawMaxPanoSizeOptions(
 
   Action action{};
   ImGui::Text("Max panorama size:");
+  ImGui::SameLine();
+  utils::imgui::InfoMarker("(?)",
+                           "If the panorama is larger it will be downscaled.\n "
+                           "A warning will be shown when this happens.");
   ImGui::Spacing();
   if (ImGui::InputInt("[MPx]", &stitch_options->max_pano_mpx)) {
     stitch_options->max_pano_mpx = std::max(stitch_options->max_pano_mpx, 1);

--- a/xpano/gui/panels/sidebar.cc
+++ b/xpano/gui/panels/sidebar.cc
@@ -332,12 +332,22 @@ Action DrawBlendingOptions(pipeline::StitchAlgorithmOptions* stitch_options) {
 
 Action DrawMaxPanoSizeOptions(
     pipeline::StitchAlgorithmOptions* stitch_options) {
+  static bool show_apply_button = false;
+
   Action action{};
   ImGui::Text("Max panorama size:");
   ImGui::Spacing();
-  if (ImGui::InputInt("[MPx]",
-                      &stitch_options->max_pano_mpx)) {
+  if (ImGui::InputInt("[MPx]", &stitch_options->max_pano_mpx)) {
     stitch_options->max_pano_mpx = std::max(stitch_options->max_pano_mpx, 1);
+    show_apply_button = true;
+  }
+
+  if (show_apply_button) {
+    ImGui::SameLine();
+    if (ImGui::Button("Apply")) {
+      action |= {ActionType::kRecomputePanoFullRes};
+      show_apply_button = false;
+    }
   }
   return action;
 }

--- a/xpano/gui/panels/warning_pane.cc
+++ b/xpano/gui/panels/warning_pane.cc
@@ -38,6 +38,8 @@ const char* WarningMessage(WarningType warning) {
       return "File format is not supported!";
     case WarningType::kFilePickerUnknownError:
       return "File picker error!";
+    case WarningType::kResolutionCapped:
+      return "Image resolution was capped!";
     default:
       return "";
   }
@@ -59,6 +61,8 @@ const char* Title(WarningType warning) {
 bool EnableSnooze(WarningType warning) {
   switch (warning) {
     case WarningType::kWarnInputConversion:
+      [[fallthrough]];
+    case WarningType::kResolutionCapped:
       return true;
     default:
       return false;
@@ -142,6 +146,10 @@ void WarningPane::DrawExtra(const Warning& warning) {
       ImGui::EndChild();
       break;
     }
+    case WarningType::kResolutionCapped: {
+      ImGui::TextUnformatted(warning.extra_message.c_str());
+      break;
+    }
     default:
       break;
   }
@@ -176,6 +184,14 @@ void WarningPane::QueueFilePickerError(const file_dialog::Error& error) {
     default:
       break;
   }
+}
+
+void WarningPane::QueueResolutionCapped(int mpx_limit) {
+  pending_warnings_.push(
+      {WarningType::kResolutionCapped,
+       fmt::format(" - the current limit is {} MPx\n - "
+                   "increase it in Options -> Panorama stitching",
+                   mpx_limit)});
 }
 
 void WarningPane::Show(Warning warning) {

--- a/xpano/gui/panels/warning_pane.h
+++ b/xpano/gui/panels/warning_pane.h
@@ -23,7 +23,8 @@ enum class WarningType {
   kUserPrefResetOnRequest,
   kNewVersion,
   kFilePickerUnsupportedExt,
-  kFilePickerUnknownError
+  kFilePickerUnknownError,
+  kResolutionCapped
 };
 
 struct Warning {
@@ -38,6 +39,7 @@ class WarningPane {
   void QueueNewVersion(version::Triplet previous_version,
                        std::optional<utils::Text> changelog);
   void QueueFilePickerError(const file_dialog::Error& error);
+  void QueueResolutionCapped(int mpx_limit);
 
  private:
   void Show(Warning warning);

--- a/xpano/gui/pano_gui.cc
+++ b/xpano/gui/pano_gui.cc
@@ -614,6 +614,7 @@ void PanoGui::PerformExportAction(int pano_id) {
   }
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity): fixme
 MultiAction PanoGui::ResolveFutures() {
   MultiAction actions;
   auto handle_stitcher_data =

--- a/xpano/pipeline/stitcher_pipeline.cc
+++ b/xpano/pipeline/stitcher_pipeline.cc
@@ -44,17 +44,18 @@ cv::ImwriteJPEGSamplingFactorParams ToOpenCVEnum(
 #endif
 
 std::vector<int> CompressionParameters(const CompressionOptions &options) {
-  return {
-    cv::IMWRITE_JPEG_QUALITY, options.jpeg_quality,
-        cv::IMWRITE_JPEG_PROGRESSIVE,
-        static_cast<int>(options.jpeg_progressive), cv::IMWRITE_JPEG_OPTIMIZE,
-        static_cast<int>(options.jpeg_optimize),
+  return {cv::IMWRITE_JPEG_QUALITY,
+          options.jpeg_quality,
+          cv::IMWRITE_JPEG_PROGRESSIVE,
+          static_cast<int>(options.jpeg_progressive),
+          cv::IMWRITE_JPEG_OPTIMIZE,
+          static_cast<int>(options.jpeg_optimize),
 #if XPANO_OPENCV_HAS_JPEG_SUBSAMPLING_SUPPORT
-        cv::IMWRITE_JPEG_SAMPLING_FACTOR,
-        ToOpenCVEnum(options.jpeg_subsampling),
+          cv::IMWRITE_JPEG_SAMPLING_FACTOR,
+          ToOpenCVEnum(options.jpeg_subsampling),
 #endif
-        cv::IMWRITE_PNG_COMPRESSION, options.png_compression
-  };
+          cv::IMWRITE_PNG_COMPRESSION,
+          options.png_compression};
 }
 
 template <typename TFutureType, RunTraits run>
@@ -234,7 +235,7 @@ StitchingResult RunStitchingPipeline(
                          .progress_monitor = progress});
   progress->NotifyTaskDone();
 
-  if (status != algorithm::stitcher::Status::kSuccess) {
+  if (!IsSuccess(status)) {
     return StitchingResult{
         .pano_id = options.pano_id,
         .full_res = options.full_res,

--- a/xpano/utils/opencv.cc
+++ b/xpano/utils/opencv.cc
@@ -32,4 +32,13 @@ cv::Mat ToFloat(const cv::Mat &image) {
   return float_image;
 }
 
+float MPx(const cv::Rect &rect) {
+  return static_cast<float>(rect.width) * static_cast<float>(rect.height) /
+         1e6f;
+}
+
+float MPx(const cv::Mat &image) {
+  return MPx(cv::Rect(0, 0, image.cols, image.rows));
+}
+
 }  // namespace xpano::utils::opencv

--- a/xpano/utils/opencv.h
+++ b/xpano/utils/opencv.h
@@ -25,4 +25,8 @@ std::vector<cv::detail::CameraParams> Scale(
 
 cv::Mat ToFloat(const cv::Mat &image);
 
+float MPx(const cv::Rect &rect);
+
+float MPx(const cv::Mat &image);
+
 }  // namespace xpano::utils::opencv

--- a/xpano/utils/vec.h
+++ b/xpano/utils/vec.h
@@ -65,10 +65,9 @@ constexpr auto DivideByConstant(const Vec<TType, N, Tag>& lhs, TRight rhs,
 }
 
 template <typename TType, size_t N, typename Tag, std::size_t... Index>
-constexpr auto DivideByItself(const Vec<TType, N, Tag>& lhs,
-                              const Vec<TType, N, Tag>& rhs,
-                              std::index_sequence<Index...> /*unused*/)
-    -> Vec<float, N, Ratio> {
+constexpr auto DivideByItself(
+    const Vec<TType, N, Tag>& lhs, const Vec<TType, N, Tag>& rhs,
+    std::index_sequence<Index...> /*unused*/) -> Vec<float, N, Ratio> {
   if constexpr (std::is_floating_point_v<TType>) {
     return {lhs[Index] / rhs[Index]...};
   } else {
@@ -95,8 +94,8 @@ constexpr auto MultiplyByRatio(const Vec<TType, N, Tag>& lhs,
 
 template <typename TagLeft, typename TagRight>
 concept Addable =
-    !(std::same_as<TagLeft, Point> && std::same_as<TagRight, Point>) && !
-std::same_as<TagLeft, Ratio> && !std::same_as<TagRight, Ratio>;
+    !(std::same_as<TagLeft, Point> && std::same_as<TagRight, Point>) &&
+    !std::same_as<TagLeft, Ratio> && !std::same_as<TagRight, Ratio>;
 
 template <typename TagLeft, typename TagRight>
 using AddResultTag = std::conditional_t<std::is_same_v<TagLeft, Vector> &&

--- a/xpano/version_fmt.h
+++ b/xpano/version_fmt.h
@@ -12,8 +12,8 @@
 template <>
 struct fmt::formatter<xpano::version::Triplet> : formatter<std::string> {
   template <typename FormatContext>
-  auto format(const xpano::version::Triplet& version, FormatContext& ctx) const
-      -> decltype(ctx.out()) {
+  auto format(const xpano::version::Triplet& version,
+              FormatContext& ctx) const -> decltype(ctx.out()) {
     return fmt::format_to(ctx.out(), "{}.{}.{}", std::get<0>(version),
                           std::get<1>(version), std::get<2>(version));
   }


### PR DESCRIPTION
User can limit the max pano size in MPx, with the benefit that the app will automatically shrink the panorama to the selected MPx limit. This replaces the previous behavior where the app didn't stitch a pano if it was over a set resolution limit.

Default limit is 100 MPx.

![image](https://github.com/user-attachments/assets/4f27c6ce-de66-4cd8-9ab5-fe4930e3f8a6)

Resolves #127 



