### PR TITLE
Fix thumbnail tooltip crash

### DIFF
--- a/xpano/gui/panels/thumbnail_pane.cc
+++ b/xpano/gui/panels/thumbnail_pane.cc
@@ -203,7 +203,7 @@ void ThumbnailPane::ThumbnailTooltip(const std::vector<int> &images) const {
   }
   ImGui::BeginTooltip();
   for (const int img_id : images) {
-    ImGui::PushID(coord_id);
+    ImGui::PushID(img_id);
     ThumbnailButton(img_id);
     ImGui::PopID();
     ImGui::SameLine();

--- a/xpano/gui/panels/thumbnail_pane.cc
+++ b/xpano/gui/panels/thumbnail_pane.cc
@@ -203,7 +203,9 @@ void ThumbnailPane::ThumbnailTooltip(const std::vector<int> &images) const {
   }
   ImGui::BeginTooltip();
   for (const int img_id : images) {
+    ImGui::PushID(coord_id);
     ThumbnailButton(img_id);
+    ImGui::PopID();
     ImGui::SameLine();
   }
   ImGui::EndTooltip();


### PR DESCRIPTION
Thumbnail tooltips would crash the app
 - introduced in https://github.com/krupkat/xpano/commit/16caf69139b50da4f562578a4f5fa166b5df3c8a
 - https://github.com/ocornut/imgui/releases/tag/v1.91.1